### PR TITLE
Create board.Canvas interface

### DIFF
--- a/cmd/sportsmatrix/main.go
+++ b/cmd/sportsmatrix/main.go
@@ -93,7 +93,10 @@ func newRootCmd(args *rootArgs) *cobra.Command {
 			}
 
 			args.setConfigDefaults()
-			args.setTodayFuncs(viper.GetString("date-str"))
+
+			if err := args.setTodayFuncs(viper.GetString("date-str")); err != nil {
+				return err
+			}
 
 			return nil
 		},

--- a/cmd/sportsmatrix/mlbtest.go
+++ b/cmd/sportsmatrix/mlbtest.go
@@ -79,7 +79,9 @@ func (c *mlbCmd) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	mtrx, err := sportsmatrix.New(ctx, logger, c.rArgs.config.SportsMatrixConfig, matrix, boards...)
+	canvas := rgb.NewCanvas(matrix)
+
+	mtrx, err := sportsmatrix.New(ctx, logger, c.rArgs.config.SportsMatrixConfig, canvas, boards...)
 	if err != nil {
 		return err
 	}

--- a/cmd/sportsmatrix/nhltest.go
+++ b/cmd/sportsmatrix/nhltest.go
@@ -89,7 +89,9 @@ func (c *nhlCmd) run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	mtrx, err := sportsmatrix.New(ctx, logger, c.rArgs.config.SportsMatrixConfig, matrix, boards...)
+	canvas := rgb.NewCanvas(matrix)
+
+	mtrx, err := sportsmatrix.New(ctx, logger, c.rArgs.config.SportsMatrixConfig, canvas, boards...)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/gorilla/mux v1.8.0
 	github.com/hashicorp/go-multierror v1.0.0
+	github.com/jphsd/glui v0.0.0-20210213195601-206b7774bf97 // indirect
 	github.com/mackerelio/go-osstat v0.1.0
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7 h1:SCYMcCJ89LjRGwEa0tRluNRiMjZHalQZrVrvTbPh+qw=
+github.com/go-gl/gl v0.0.0-20190320180904-bf2b1f2f34d7/go.mod h1:482civXOzJJCPzJ4ZOX/pwvXBWSnzD4OKMdH4ClKGbk=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1 h1:QbL/5oDUmRBzO9/Z7Seo6zf912W/a6Sr4Eu0G/3Jho0=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -111,6 +113,8 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jezek/xgb v0.0.0-20210121230032-cec22bda1ce1 h1:PfWseRCw8CuibmqANiYO1Ln5yHm6NfVGAQaGGvuPjH0=
 github.com/jezek/xgb v0.0.0-20210121230032-cec22bda1ce1/go.mod h1:3P4UH/k22rXyHIJD2w4h2XMqPX4Of/eySEZq9L6wqc4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jphsd/glui v0.0.0-20210213195601-206b7774bf97 h1:35fypACWfxgz6KfYYxr6mDqrnN0Wtgs+jQGuQ43T6NU=
+github.com/jphsd/glui v0.0.0-20210213195601-206b7774bf97/go.mod h1:VPZT7ZiQP8fwSHjtpzAh/1bINPQaj9tZNmxIf7LXz28=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=

--- a/pkg/board/board.go
+++ b/pkg/board/board.go
@@ -2,9 +2,9 @@ package board
 
 import (
 	"context"
+	"image"
+	"image/draw"
 	"net/http"
-
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 )
 
 // HTTPHandler is the type returned to the sportsmatrix for HTTP endpoints
@@ -16,7 +16,15 @@ type HTTPHandler struct {
 // Board is the interface to implement for displaying on the matrix
 type Board interface {
 	Name() string
-	Render(ctx context.Context, matrix rgb.Matrix) error
+	Render(ctx context.Context, canvas Canvas) error
 	Enabled() bool
 	GetHTTPHandlers() ([]*HTTPHandler, error)
+}
+
+// Canvas ...
+type Canvas interface {
+	image.Image
+	draw.Image
+	Clear() error
+	Render() error
 }

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -12,7 +12,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/robbydyer/sports/pkg/board"
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
@@ -78,9 +77,7 @@ func (c *Clock) Enabled() bool {
 
 func (c *Clock) Cleanup() {}
 
-func (c *Clock) Render(ctx context.Context, matrix rgb.Matrix) error {
-	canvas := rgb.NewCanvas(matrix)
-
+func (c *Clock) Render(ctx context.Context, canvas board.Canvas) error {
 	if !c.config.Enabled.Load() {
 		return nil
 	}

--- a/pkg/imageboard/imageboard.go
+++ b/pkg/imageboard/imageboard.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
+	"github.com/robbydyer/sports/pkg/board"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
@@ -104,7 +104,7 @@ func (i *ImageBoard) Enabled() bool {
 }
 
 // Render ...
-func (i *ImageBoard) Render(ctx context.Context, matrix rgb.Matrix) error {
+func (i *ImageBoard) Render(ctx context.Context, canvas board.Canvas) error {
 	if !i.config.Enabled.Load() {
 		i.log.Warn("ImageBoard is disabled, not rendering")
 		return nil
@@ -137,7 +137,6 @@ func (i *ImageBoard) Render(ctx context.Context, matrix rgb.Matrix) error {
 		}
 	}
 
-	canvas := rgb.NewCanvas(matrix)
 	for _, img := range i.imageCache {
 		if !i.config.Enabled.Load() {
 			i.log.Warn("ImageBoard is disabled, not rendering")

--- a/pkg/logo/logo.go
+++ b/pkg/logo/logo.go
@@ -9,7 +9,6 @@ import (
 
 	"go.uber.org/zap"
 
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
@@ -113,7 +112,7 @@ func (l *Logo) GetThumbnail(size image.Rectangle) (image.Image, error) {
 }
 
 // RenderLeftAligned renders the logo on the left side of the matrix
-func (l *Logo) RenderLeftAligned(canvas *rgb.Canvas, width int) (image.Image, error) {
+func (l *Logo) RenderLeftAligned(bounds image.Rectangle, width int) (image.Image, error) {
 	thumb, err := l.GetThumbnail(l.bounds)
 	if err != nil {
 		return nil, err
@@ -122,16 +121,16 @@ func (l *Logo) RenderLeftAligned(canvas *rgb.Canvas, width int) (image.Image, er
 	startX := width - thumb.Bounds().Dx() + l.config.Pt.X
 	startY := 0 + l.config.Pt.Y
 
-	bounds := image.Rect(startX, startY, canvas.Bounds().Dx()-1, canvas.Bounds().Dy()-1)
+	newBounds := image.Rect(startX, startY, bounds.Dx()-1, bounds.Dy()-1)
 
 	i := image.NewRGBA(bounds)
-	draw.Draw(i, bounds, thumb, image.Point{}, draw.Over)
+	draw.Draw(i, newBounds, thumb, image.Point{}, draw.Over)
 
 	return i, nil
 }
 
 // RenderRightAligned renders the logo on the right side of the matrix
-func (l *Logo) RenderRightAligned(canvas *rgb.Canvas, width int) (image.Image, error) {
+func (l *Logo) RenderRightAligned(bounds image.Rectangle, width int) (image.Image, error) {
 	thumb, err := l.GetThumbnail(l.bounds)
 	if err != nil {
 		return nil, err
@@ -140,10 +139,10 @@ func (l *Logo) RenderRightAligned(canvas *rgb.Canvas, width int) (image.Image, e
 	startX := width + l.config.Pt.X
 	startY := 0 + l.config.Pt.Y
 
-	bounds := image.Rect(startX, startY, canvas.Bounds().Dx()-1, canvas.Bounds().Dy()-1)
+	newBounds := image.Rect(startX, startY, bounds.Dx()-1, bounds.Dy()-1)
 
 	i := image.NewRGBA(bounds)
-	draw.Draw(i, bounds, thumb, image.Point{}, draw.Over)
+	draw.Draw(i, newBounds, thumb, image.Point{}, draw.Over)
 
 	return i, nil
 }

--- a/pkg/mlb/mlb.go
+++ b/pkg/mlb/mlb.go
@@ -17,9 +17,12 @@ const (
 	baseURL      = "https://statsapi.mlb.com/api"
 	linkBase     = "https://statsapi.mlb.com"
 	logoCacheDir = "/tmp/sportsmatrix_logos/mlb"
-	DateFormat   = "2006-01-02"
+
+	// DateFormat is the game schedule format for querying a particular day from the API
+	DateFormat = "2006-01-02"
 )
 
+// DefaultLogoConfigs contains default logo alignedment configurations
 type DefaultLogoConfigs *[]*logo.Config
 
 // MLB implements a sportboard.API
@@ -52,6 +55,7 @@ func New(ctx context.Context, logger *zap.Logger) (*MLB, error) {
 	return m, nil
 }
 
+// HTTPPathPrefix returns the path prefix for the HTTP handlers for this board
 func (m *MLB) HTTPPathPrefix() string {
 	return "mlb"
 }
@@ -103,7 +107,7 @@ func (m *MLB) GetScheduledGames(ctx context.Context, date time.Time) ([]sportboa
 	return gList, nil
 }
 
-// DateStr
+// DateStr ...
 func (m *MLB) DateStr(d time.Time) string {
 	return d.Format(DateFormat)
 }

--- a/pkg/mlb/mock.go
+++ b/pkg/mlb/mock.go
@@ -170,7 +170,7 @@ func MockLiveGameGetter(ctx context.Context, link string) (sportboard.Game, erro
 	return nil, fmt.Errorf("could not locate live game with Link '%s'", link)
 }
 
-// New ...
+// NewMock ...
 func NewMock(logger *zap.Logger) (*MockMLBAPI, error) {
 	// Load Teams
 	dat, err := assets.ReadFile("assets/mock_teams.yaml")

--- a/pkg/rgbrender/img.go
+++ b/pkg/rgbrender/img.go
@@ -14,6 +14,7 @@ import (
 	"github.com/nfnt/resize"
 	"github.com/spf13/afero"
 
+	"github.com/robbydyer/sports/pkg/board"
 	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 )
 
@@ -115,13 +116,13 @@ func DrawImageAligned(canvas *rgb.Canvas, bounds image.Rectangle, img *image.RGB
 }
 
 // DrawImage draws an image
-func DrawImage(canvas *rgb.Canvas, bounds image.Rectangle, img image.Image) error {
+func DrawImage(canvas draw.Image, bounds image.Rectangle, img image.Image) error {
 	draw.Draw(canvas, bounds, img, img.Bounds().Min, draw.Over)
 	return nil
 }
 
 // PlayImages plays s series of images. If loop == 0, it will play forever until the context is canceled
-func PlayImages(ctx context.Context, canvas *rgb.Canvas, images []image.Image, delay []time.Duration, loop int) error {
+func PlayImages(ctx context.Context, canvas board.Canvas, images []image.Image, delay []time.Duration, loop int) error {
 	center, err := AlignPosition(CenterCenter, canvas.Bounds(), images[0].Bounds().Dx(), images[0].Bounds().Dy())
 	if err != nil {
 		return err
@@ -165,7 +166,7 @@ func PlayImages(ctx context.Context, canvas *rgb.Canvas, images []image.Image, d
 
 // PlayGIF reads and draw a gif file from r. It use the contained images and
 // delays and loops over it, until a true is sent to the returned chan
-func PlayGIF(ctx context.Context, canvas *rgb.Canvas, gif *gif.GIF) error {
+func PlayGIF(ctx context.Context, canvas board.Canvas, gif *gif.GIF) error {
 	delay := make([]time.Duration, len(gif.Image))
 	images := make([]image.Image, len(gif.Image))
 	for i, image := range gif.Image {

--- a/pkg/rgbrender/text.go
+++ b/pkg/rgbrender/text.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"image"
 	"image/color"
+	"image/draw"
 	"math"
 	"path/filepath"
 	"strings"
@@ -13,8 +14,6 @@ import (
 
 	"golang.org/x/image/font"
 	"golang.org/x/image/math/fixed"
-
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 )
 
 //go:embed assets/fonts
@@ -83,7 +82,7 @@ func GetFont(name string) (*truetype.Font, error) {
 }
 
 // Write ...
-func (t *TextWriter) Write(canvas *rgb.Canvas, bounds image.Rectangle, str []string, clr color.Color) error {
+func (t *TextWriter) Write(canvas draw.Image, bounds image.Rectangle, str []string, clr color.Color) error {
 	startX := bounds.Min.X + t.XStartCorrection
 	drawer := &font.Drawer{
 		Dst: canvas,
@@ -112,7 +111,7 @@ func (t *TextWriter) Write(canvas *rgb.Canvas, bounds image.Rectangle, str []str
 }
 
 // WriteCentered writes text in the center of the canvas, horizontally and vertically
-func (t *TextWriter) WriteCentered(canvas *rgb.Canvas, bounds image.Rectangle, str []string, clr color.Color) error {
+func (t *TextWriter) WriteCentered(canvas draw.Image, bounds image.Rectangle, str []string, clr color.Color) error {
 	drawer := &font.Drawer{
 		Dst: canvas,
 		Src: image.NewUniform(clr),

--- a/pkg/sportboard/game_counter.go
+++ b/pkg/sportboard/game_counter.go
@@ -6,12 +6,12 @@ import (
 
 	"go.uber.org/zap"
 
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
+	"github.com/robbydyer/sports/pkg/board"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
 // RenderGameCounter ...
-func (s *SportBoard) RenderGameCounter(canvas *rgb.Canvas, numGames int, activeIndex int, spacing int) (image.Image, error) {
+func (s *SportBoard) RenderGameCounter(canvas board.Canvas, numGames int, activeIndex int, spacing int) (image.Image, error) {
 	totalWidth := (numGames * spacing) + numGames - 1
 
 	aligned, err := rgbrender.AlignPosition(rgbrender.CenterBottom, canvas.Bounds(), totalWidth, 1)

--- a/pkg/sportboard/logo.go
+++ b/pkg/sportboard/logo.go
@@ -8,8 +8,8 @@ import (
 
 	"go.uber.org/zap"
 
+	"github.com/robbydyer/sports/pkg/board"
 	"github.com/robbydyer/sports/pkg/logo"
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 )
 
 func (s *SportBoard) logoConfig(logoKey string) (*logo.Config, error) {
@@ -24,7 +24,7 @@ func (s *SportBoard) logoConfig(logoKey string) (*logo.Config, error) {
 }
 
 // RenderHomeLogo ...
-func (s *SportBoard) RenderHomeLogo(ctx context.Context, canvas *rgb.Canvas, abbreviation string) error {
+func (s *SportBoard) RenderHomeLogo(ctx context.Context, canvas board.Canvas, abbreviation string) error {
 	select {
 	case <-ctx.Done():
 		return context.Canceled
@@ -61,7 +61,7 @@ func (s *SportBoard) RenderHomeLogo(ctx context.Context, canvas *rgb.Canvas, abb
 
 	textWdith := s.textAreaWidth()
 	logoWidth := (s.matrixBounds.Dx() - textWdith) / 2
-	renderedLogo, err := l.RenderLeftAligned(canvas, logoWidth)
+	renderedLogo, err := l.RenderLeftAligned(canvas.Bounds(), logoWidth)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (s *SportBoard) RenderHomeLogo(ctx context.Context, canvas *rgb.Canvas, abb
 }
 
 // RenderAwayLogo ...
-func (s *SportBoard) RenderAwayLogo(ctx context.Context, canvas *rgb.Canvas, abbreviation string) error {
+func (s *SportBoard) RenderAwayLogo(ctx context.Context, canvas board.Canvas, abbreviation string) error {
 	select {
 	case <-ctx.Done():
 		return context.Canceled
@@ -110,7 +110,7 @@ func (s *SportBoard) RenderAwayLogo(ctx context.Context, canvas *rgb.Canvas, abb
 	textWdith := s.textAreaWidth()
 	logoWidth := (s.matrixBounds.Dx() - textWdith) / 2
 
-	renderedLogo, err := l.RenderRightAligned(canvas, logoWidth+textWdith)
+	renderedLogo, err := l.RenderRightAligned(canvas.Bounds(), logoWidth+textWdith)
 	if err != nil {
 		return err
 	}

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -9,10 +9,10 @@ import (
 
 	"go.uber.org/zap"
 
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
+	"github.com/robbydyer/sports/pkg/board"
 )
 
-func (s *SportBoard) renderLiveGame(ctx context.Context, canvas *rgb.Canvas, liveGame Game) error {
+func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, liveGame Game) error {
 	awayTeam, err := liveGame.AwayTeam()
 	if err != nil {
 		return err
@@ -129,7 +129,7 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas *rgb.Canvas, liv
 	}
 }
 
-func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas *rgb.Canvas, liveGame Game) error {
+func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas board.Canvas, liveGame Game) error {
 	renderCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	awayTeam, err := liveGame.AwayTeam()
@@ -193,7 +193,7 @@ func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas *rgb.Canvas,
 	return canvas.Render()
 }
 
-func (s *SportBoard) renderCompleteGame(ctx context.Context, canvas *rgb.Canvas, liveGame Game) error {
+func (s *SportBoard) renderCompleteGame(ctx context.Context, canvas board.Canvas, liveGame Game) error {
 	renderCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	awayTeam, err := liveGame.AwayTeam()

--- a/pkg/sportboard/sportboard.go
+++ b/pkg/sportboard/sportboard.go
@@ -13,8 +13,8 @@ import (
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
 
+	"github.com/robbydyer/sports/pkg/board"
 	"github.com/robbydyer/sports/pkg/logo"
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 	"github.com/robbydyer/sports/pkg/util"
 )
@@ -215,12 +215,11 @@ func (s *SportBoard) Enabled() bool {
 }
 
 // Render ...
-func (s *SportBoard) Render(ctx context.Context, matrix rgb.Matrix) error {
+func (s *SportBoard) Render(ctx context.Context, canvas board.Canvas) error {
 	if !s.config.Enabled.Load() {
 		s.log.Warn("skipping disabled board", zap.String("board", s.api.League()))
 		return nil
 	}
-	canvas := rgb.NewCanvas(matrix)
 
 	allGames, err := s.api.GetScheduledGames(ctx, s.config.TodayFunc())
 	if err != nil {
@@ -342,7 +341,7 @@ OUTER:
 	return nil
 }
 
-func (s *SportBoard) renderGame(ctx context.Context, canvas *rgb.Canvas, liveGame Game) error {
+func (s *SportBoard) renderGame(ctx context.Context, canvas board.Canvas, liveGame Game) error {
 	select {
 	case <-ctx.Done():
 		return context.Canceled

--- a/pkg/sportsmatrix/http.go
+++ b/pkg/sportsmatrix/http.go
@@ -16,6 +16,7 @@ import (
 //go:embed assets
 var assets embed.FS
 
+// EmbedDir is a wrapper to return index.html by default
 type EmbedDir struct {
 	http.FileSystem
 }
@@ -24,9 +25,9 @@ type EmbedDir struct {
 func (d EmbedDir) Open(name string) (http.File, error) {
 	if f, err := d.FileSystem.Open(name); err == nil {
 		return f, nil
-	} else {
-		return d.FileSystem.Open("/index.html")
 	}
+
+	return d.FileSystem.Open("/index.html")
 }
 
 func (s *SportsMatrix) startHTTP() chan error {

--- a/pkg/sysboard/sysboard.go
+++ b/pkg/sysboard/sysboard.go
@@ -13,7 +13,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/robbydyer/sports/pkg/board"
-	rgb "github.com/robbydyer/sports/pkg/rgbmatrix-rpi"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
@@ -68,12 +67,10 @@ func (s *SysBoard) Name() string {
 }
 
 // Render ...
-func (s *SysBoard) Render(ctx context.Context, matrix rgb.Matrix) error {
+func (s *SysBoard) Render(ctx context.Context, canvas board.Canvas) error {
 	if !s.config.Enabled.Load() {
 		return nil
 	}
-
-	canvas := rgb.NewCanvas(matrix)
 
 	mem, err := memory.Get()
 	if err != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -47,6 +47,8 @@ github.com/jezek/xgb
 github.com/jezek/xgb/render
 github.com/jezek/xgb/shm
 github.com/jezek/xgb/xproto
+# github.com/jphsd/glui v0.0.0-20210213195601-206b7774bf97
+## explicit
 # github.com/kr/text v0.1.0
 github.com/kr/text
 # github.com/mackerelio/go-osstat v0.1.0


### PR DESCRIPTION
This creates a new interface `board.Canvas` that is used for the rendering, instead of directly using `rgbmatrix-rpi.Canvas` struct. This opens the door for different canvas types in the future.