### PR TITLE
Add support for TOP25 type watch teams

### DIFF
--- a/pkg/espnboard/espnboard.go
+++ b/pkg/espnboard/espnboard.go
@@ -101,6 +101,7 @@ func (e *ESPNBoard) CacheClear(ctx context.Context) {
 	}
 	e.allTeams = []string{}
 	e.teams = nil
+	e.rankSorted.Store(false)
 	if _, err := e.GetTeams(ctx); err != nil {
 		e.log.Error("failed to get teams after cache clear", zap.Error(err))
 	}

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -129,11 +129,11 @@ ncaafConfig:
 
   # watchTeams are teams we show games for. ALL shows all teams in the league
   watchTeams:
-  - ALL
+  - TOP25
 
-  # favoriteTeams are teams that we can hide scores for, and set to "Sticky" on live games
+  # favoriteTeams are teams that we can hide scores for, and set to "Sticky" on live games. Roll Tide.
   #favoriteTeams:
-  #- ATL
+  #- ALA
 
   # Hides scores for your favoriteTeams games. DVR is a father's life saver
   hideFavoriteScore: true


### PR DESCRIPTION
Adds support for `TOP25` style settings in `watchTeams` for each sport. You can set this to any arbitrary number, i.e. `TOP5`, `TOP6`, etc.