### PR TITLE
Score update Repeat

### DIFF
--- a/pkg/sportboard/previous_score.go
+++ b/pkg/sportboard/previous_score.go
@@ -1,19 +1,20 @@
 package sportboard
 
 import (
-	"sync"
-
 	"go.uber.org/atomic"
+	"go.uber.org/zap"
 )
 
 type previousScore struct {
-	id              int
-	home            int
-	away            int
-	init            *atomic.Bool
-	testScoreChange *atomic.Bool
-	fakeBit         int
-	sync.Mutex
+	id   int
+	home *previousTeam
+	away *previousTeam
+}
+type previousTeam struct {
+	previous   *atomic.Int32
+	repeats    *atomic.Int32
+	init       *atomic.Bool
+	maxRepeats int32
 }
 
 func (s *SportBoard) storeOrGetPreviousScore(id int, away int, home int) *previousScore {
@@ -26,55 +27,47 @@ func (s *SportBoard) storeOrGetPreviousScore(id int, away int, home int) *previo
 		}
 	}
 	p := &previousScore{
-		id:              id,
-		home:            home,
-		away:            away,
-		init:            atomic.NewBool(false),
-		testScoreChange: atomic.NewBool(false),
-	}
-	if s.config.TestScoreChange {
-		p.testScoreChange.Store(true)
+		id: id,
+		home: &previousTeam{
+			init:       atomic.NewBool(false),
+			previous:   atomic.NewInt32(int32(home)),
+			repeats:    atomic.NewInt32(0),
+			maxRepeats: int32(*s.config.ScoreHighlightRepeat),
+		},
+		away: &previousTeam{
+			init:       atomic.NewBool(false),
+			previous:   atomic.NewInt32(int32(away)),
+			repeats:    atomic.NewInt32(0),
+			maxRepeats: int32(*s.config.ScoreHighlightRepeat),
+		},
 	}
 	s.previousScores = append(s.previousScores, p)
+
+	s.log.Debug("storing game previous score",
+		zap.Int("id", id),
+		zap.Int32("home repeat", p.home.maxRepeats),
+		zap.Int32("away repeat", p.home.maxRepeats),
+	)
 
 	return p
 }
 
-func (p *previousScore) homeScored(currentScore int) bool {
-	p.Lock()
-	defer p.Unlock()
-	if !p.init.Load() {
-		p.init.Store(true)
+func (t *previousTeam) hasScored(current int) bool {
+	if !t.init.Load() {
+		t.previous.Store(int32(current))
+		t.init.Store(true)
 		return false
 	}
-	if p.testScoreChange.Load() {
-		return p.fakeBit == 1
-	}
-	if currentScore != p.home {
-		p.home = currentScore
+
+	c := int32(current)
+	if c != t.previous.Load() {
+		t.previous.Store(c)
+		t.repeats.Store(0)
 		return true
 	}
 
-	return false
-}
-
-func (p *previousScore) awayScored(currentScore int) bool {
-	p.Lock()
-	defer p.Unlock()
-	if !p.init.Load() {
-		p.init.Store(true)
-		return false
-	}
-	if p.testScoreChange.Load() {
-		if p.fakeBit == 1 {
-			p.fakeBit = 0
-			return true
-		}
-		p.fakeBit = 1
-		return false
-	}
-	if currentScore != p.away {
-		p.away = currentScore
+	if t.repeats.Load() < t.maxRepeats {
+		t.repeats.Inc()
 		return true
 	}
 

--- a/pkg/sportboard/previous_score.go
+++ b/pkg/sportboard/previous_score.go
@@ -10,6 +10,7 @@ type previousScore struct {
 	home *previousTeam
 	away *previousTeam
 }
+
 type previousTeam struct {
 	previous   *atomic.Int32
 	repeats    *atomic.Int32
@@ -46,7 +47,7 @@ func (s *SportBoard) storeOrGetPreviousScore(id int, away int, home int) *previo
 	s.log.Debug("storing game previous score",
 		zap.Int("id", id),
 		zap.Int32("home repeat", p.home.maxRepeats),
-		zap.Int32("away repeat", p.home.maxRepeats),
+		zap.Int32("away repeat", p.away.maxRepeats),
 	)
 
 	return p

--- a/pkg/sportboard/previous_score_test.go
+++ b/pkg/sportboard/previous_score_test.go
@@ -1,0 +1,62 @@
+package sportboard
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+)
+
+func TestPreviousScore(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		max  int32
+	}{
+		{
+			name: "three",
+			max:  3,
+		},
+		{
+			name: "none",
+			max:  0,
+		},
+		{
+			name: "one",
+			max:  1,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			team := &previousTeam{
+				init:       atomic.NewBool(false),
+				previous:   atomic.NewInt32(0),
+				repeats:    atomic.NewInt32(0),
+				maxRepeats: test.max,
+			}
+
+			// First one should init
+			require.False(t, team.hasScored(1))
+
+			require.True(t, team.hasScored(2))
+
+			var count int32
+			count = 0
+			for i := 0; i < int(test.max)+1; i++ {
+				if i < int(test.max) {
+					require.True(t, team.hasScored(2))
+					count++
+					continue
+				}
+				require.False(t, team.hasScored(2))
+			}
+
+			require.Equal(t, count, test.max)
+		})
+	}
+}

--- a/pkg/sportboard/previous_score_test.go
+++ b/pkg/sportboard/previous_score_test.go
@@ -45,8 +45,7 @@ func TestPreviousScore(t *testing.T) {
 
 			require.True(t, team.hasScored(2))
 
-			var count int32
-			count = 0
+			count := int32(0)
 			for i := 0; i < int(test.max)+1; i++ {
 				if i < int(test.max) {
 					require.True(t, team.hasScored(2))

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -182,14 +182,14 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 							"-",
 							fmt.Sprintf("%d", aScore),
 						}
-						if prev.homeScored(hScore) {
+						if prev.home.hasScored(hScore) {
 							clrs = append(clrs, red)
 							s.log.Debug("home team scored")
 						} else {
 							clrs = append(clrs, color.White)
 						}
 						clrs = append(clrs, color.White)
-						if prev.awayScored(aScore) {
+						if prev.away.hasScored(aScore) {
 							clrs = append(clrs, red)
 							s.log.Debug("away team scored")
 						} else {
@@ -201,14 +201,14 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 							"-",
 							fmt.Sprintf("%d", hScore),
 						}
-						if prev.awayScored(aScore) {
+						if prev.away.hasScored(aScore) {
 							clrs = append(clrs, red)
 							s.log.Debug("away team scored")
 						} else {
 							clrs = append(clrs, color.White)
 						}
 						clrs = append(clrs, color.White)
-						if prev.homeScored(hScore) {
+						if prev.home.hasScored(hScore) {
 							clrs = append(clrs, red)
 							s.log.Debug("home team scored")
 						} else {

--- a/pkg/sportboard/sportboard.go
+++ b/pkg/sportboard/sportboard.go
@@ -60,34 +60,34 @@ type Todayer func() []time.Time
 
 // Config ...
 type Config struct {
-	TodayFunc           Todayer
-	boardDelay          time.Duration
-	scrollDelay         time.Duration
-	TimeColor           color.Color
-	ScoreColor          color.Color
-	Enabled             *atomic.Bool      `json:"enabled"`
-	BoardDelay          string            `json:"boardDelay"`
-	FavoriteSticky      *atomic.Bool      `json:"favoriteSticky"`
-	ScoreFont           *FontConfig       `json:"scoreFont"`
-	TimeFont            *FontConfig       `json:"timeFont"`
-	LogoConfigs         []*logo.Config    `json:"logoConfigs"`
-	WatchTeams          []string          `json:"watchTeams"`
-	FavoriteTeams       []string          `json:"favoriteTeams"`
-	HideFavoriteScore   *atomic.Bool      `json:"hideFavoriteScore"`
-	ShowRecord          *atomic.Bool      `json:"showRecord"`
-	GridCols            int               `json:"gridCols"`
-	GridRows            int               `json:"gridRows"`
-	GridPadRatio        float64           `json:"gridPadRatio"`
-	MinimumGridWidth    int               `json:"minimumGridWidth"`
-	MinimumGridHeight   int               `json:"minimumGridHeight"`
-	Stats               *statboard.Config `json:"stats"`
-	ScrollMode          *atomic.Bool      `json:"scrollMode"`
-	TightScroll         *atomic.Bool      `json:"tightScroll"`
-	TightScrollPadding  int               `json:"tightScrollPadding"`
-	ScrollDelay         string            `json:"scrollDelay"`
-	GamblingSpread      *atomic.Bool      `json:"showOdds"`
-	ShowNoScheduledLogo *atomic.Bool      `json:"showNotScheduled"`
-	TestScoreChange     bool              `json:"testScoreChange"`
+	TodayFunc            Todayer
+	boardDelay           time.Duration
+	scrollDelay          time.Duration
+	TimeColor            color.Color
+	ScoreColor           color.Color
+	Enabled              *atomic.Bool      `json:"enabled"`
+	BoardDelay           string            `json:"boardDelay"`
+	FavoriteSticky       *atomic.Bool      `json:"favoriteSticky"`
+	ScoreFont            *FontConfig       `json:"scoreFont"`
+	TimeFont             *FontConfig       `json:"timeFont"`
+	LogoConfigs          []*logo.Config    `json:"logoConfigs"`
+	WatchTeams           []string          `json:"watchTeams"`
+	FavoriteTeams        []string          `json:"favoriteTeams"`
+	HideFavoriteScore    *atomic.Bool      `json:"hideFavoriteScore"`
+	ShowRecord           *atomic.Bool      `json:"showRecord"`
+	GridCols             int               `json:"gridCols"`
+	GridRows             int               `json:"gridRows"`
+	GridPadRatio         float64           `json:"gridPadRatio"`
+	MinimumGridWidth     int               `json:"minimumGridWidth"`
+	MinimumGridHeight    int               `json:"minimumGridHeight"`
+	Stats                *statboard.Config `json:"stats"`
+	ScrollMode           *atomic.Bool      `json:"scrollMode"`
+	TightScroll          *atomic.Bool      `json:"tightScroll"`
+	TightScrollPadding   int               `json:"tightScrollPadding"`
+	ScrollDelay          string            `json:"scrollDelay"`
+	GamblingSpread       *atomic.Bool      `json:"showOdds"`
+	ShowNoScheduledLogo  *atomic.Bool      `json:"showNotScheduled"`
+	ScoreHighlightRepeat *int              `json:"scoreHighlightRepeat"`
 }
 
 // FontConfig ...
@@ -195,6 +195,11 @@ func (c *Config) SetDefaults() {
 		c.scrollDelay = d
 	} else {
 		c.scrollDelay = rgbmatrix.DefaultScrollDelay
+	}
+
+	if c.ScoreHighlightRepeat == nil {
+		p := 3
+		c.ScoreHighlightRepeat = &p
 	}
 }
 

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -151,6 +151,9 @@ ncaafConfig:
   # appear if there are no scheduled games for the day
   showNotScheduled: false
 
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
+
 ## NHL config
 nhlConfig:
   enabled: true
@@ -215,6 +218,9 @@ nhlConfig:
   # If set to true and this sport is enabled, a message will
   # appear if there are no scheduled games for the day
   showNotScheduled: false
+
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
 
 ## MLB Config
 mlbConfig:
@@ -284,6 +290,9 @@ mlbConfig:
   # appear if there are no scheduled games for the day
   showNotScheduled: false
 
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
+
 ## NCAA Mens Basketball Config
 ncaamConfig:
   enabled: true
@@ -341,6 +350,9 @@ ncaamConfig:
   # appear if there are no scheduled games for the day
   showNotScheduled: false
 
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
+
 ## NBA Config
 nbaConfig:
   enabled: true
@@ -394,6 +406,9 @@ nbaConfig:
   # If set to true and this sport is enabled, a message will
   # appear if there are no scheduled games for the day
   showNotScheduled: false
+
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
 
 ## NFL Config
 nflConfig:
@@ -449,6 +464,9 @@ nflConfig:
   # appear if there are no scheduled games for the day
   showNotScheduled: false
 
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
+
 ## MLS Config
 mlsConfig:
   enabled: true
@@ -503,6 +521,9 @@ mlsConfig:
   # appear if there are no scheduled games for the day
   showNotScheduled: false
 
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
+
 ## English Premiere League Config
 eplConfig:
   enabled: true
@@ -556,6 +577,9 @@ eplConfig:
   # If set to true and this sport is enabled, a message will
   # appear if there are no scheduled games for the day
   showNotScheduled: false
+
+  # This sets the number of runs through the scoreboard that a score change will be highlighted in red
+  scoreHighlightRepeat: 3
 
 # Image Board. Rotates showing all the images in a list of directories
 # All images in the directory will be automatically scaled to fit the matrix


### PR DESCRIPTION
This sets a configurable number of times for red-highlighted score updates to repeat on subsequent board cycles. Makes it more likely to notice a change in score being highlighted. Defaults to 3 cycles.