### PR TITLE
Wide non scroll

### DIFF
--- a/Dockerfile.pibuilder
+++ b/Dockerfile.pibuilder
@@ -55,8 +55,8 @@ RUN apt-get update && \
 
 RUN GOIMG= && a="$(dpkg --print-architecture)" && \
     case "${a##*-}" in \
-      arm64) GOIMG="go1.16.7.linux-arm64.tar.gz";; \
-      amd64) GOIMG="go1.16.7.linux-amd64.tar.gz";;\
+      arm64) GOIMG="go1.17.linux-arm64.tar.gz";; \
+      amd64) GOIMG="go1.17.linux-amd64.tar.gz";;\
       *) echo "unsupported arch ${a}"; exit1 ;;\
     esac && \
     curl -L https://golang.org/dl/${GOIMG} -o /tmp/${GOIMG} && \

--- a/pkg/espnboard/logo.go
+++ b/pkg/espnboard/logo.go
@@ -58,6 +58,7 @@ func (e *ESPNBoard) GetLogo(ctx context.Context, logoKey string, logoConf *logo.
 	teamAbbrev := p[1]
 	dimKey := p[3]
 
+	e.logoLock.Lock()
 	_, ok := e.logoConfOnce[dimKey]
 	if !ok {
 		e.log.Debug("loading default logo configs",
@@ -70,6 +71,7 @@ func (e *ESPNBoard) GetLogo(ctx context.Context, logoKey string, logoConf *logo.
 		}
 		e.logoConfOnce[dimKey] = struct{}{}
 	}
+	e.logoLock.Unlock()
 
 	var l *logo.Logo
 	defer e.setLogoCache(logoKey, l)

--- a/pkg/sportboard/game_counter.go
+++ b/pkg/sportboard/game_counter.go
@@ -26,6 +26,7 @@ func (s *SportBoard) RenderGameCounter(canvas board.Canvas, numGames int, active
 
 	s.log.Debug("Rendering counter",
 		zap.Int("active index", activeIndex),
+		zap.Int("num games", numGames),
 		zap.Int("real active", realActive),
 		zap.Int("start x", aligned.Min.X),
 		zap.Int("start y", aligned.Min.Y),

--- a/pkg/sportboard/logo.go
+++ b/pkg/sportboard/logo.go
@@ -118,28 +118,18 @@ func (s *SportBoard) RenderLeftLogo(ctx context.Context, canvasBounds image.Rect
 
 	setCache := true
 
-	if s.config.ScrollMode.Load() {
-		if bounds.Dx() >= 64 && bounds.Dy() <= 64 {
-			if bounds.Dx() < 64 {
-				logoEndX -= 3
-			} else {
-				logoEndX -= 6
-			}
-		} else {
-			logoEndX -= int(float64(bounds.Dx()) * scrollLogoBufferRatio)
-		}
+	logoEndX -= int(float64(bounds.Dx()) * scrollLogoBufferRatio)
 
-		if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
-			w, err := s.getTeamInfoWidth(s.api.League(), abbreviation)
-			if err != nil {
-				w = defaultTeamInfoArea
-				setCache = false
-				s.log.Error("failed to get team info width",
-					zap.Error(err),
-				)
-			}
-			logoEndX -= w
+	if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
+		w, err := s.getTeamInfoWidth(s.api.League(), abbreviation)
+		if err != nil {
+			w = defaultTeamInfoArea
+			setCache = false
+			s.log.Error("failed to get team info width",
+				zap.Error(err),
+			)
 		}
+		logoEndX -= w
 	}
 
 	var renderErr error
@@ -199,25 +189,15 @@ func (s *SportBoard) RenderRightLogo(ctx context.Context, canvasBounds image.Rec
 
 	setCache := true
 
-	if s.config.ScrollMode.Load() {
-		if bounds.Dx() >= 64 && bounds.Dy() <= 64 {
-			if bounds.Dx() < 64 {
-				logoWidth += 3
-			} else {
-				logoWidth += 6
-			}
-		} else {
-			logoWidth += int(float64(bounds.Dx()) * scrollLogoBufferRatio)
-		}
-		if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
-			recordAdder, err = s.getTeamInfoWidth(s.api.League(), abbreviation)
-			if err != nil {
-				s.log.Error("failed to get team info width",
-					zap.Error(err),
-				)
-				recordAdder = defaultTeamInfoArea
-				setCache = false
-			}
+	logoWidth += int(float64(bounds.Dx()) * scrollLogoBufferRatio)
+	if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
+		recordAdder, err = s.getTeamInfoWidth(s.api.League(), abbreviation)
+		if err != nil {
+			s.log.Error("failed to get team info width",
+				zap.Error(err),
+			)
+			recordAdder = defaultTeamInfoArea
+			setCache = false
 		}
 	}
 

--- a/pkg/sportboard/logo.go
+++ b/pkg/sportboard/logo.go
@@ -11,7 +11,7 @@ import (
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
-const scrollLogoBufferRatio = float64(0.10)
+const scrollLogoBufferRatio = float64(0.05)
 
 func (s *SportBoard) logoConfig(logoKey string, bounds image.Rectangle) *logo.Config {
 	for _, conf := range s.config.LogoConfigs {
@@ -118,7 +118,9 @@ func (s *SportBoard) RenderLeftLogo(ctx context.Context, canvasBounds image.Rect
 
 	setCache := true
 
-	logoEndX -= int(float64(bounds.Dx()) * scrollLogoBufferRatio)
+	if s.config.ScrollMode.Load() {
+		logoEndX -= int(float64(bounds.Dx()) * scrollLogoBufferRatio)
+	}
 
 	if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
 		w, err := s.getTeamInfoWidth(s.api.League(), abbreviation)
@@ -189,7 +191,10 @@ func (s *SportBoard) RenderRightLogo(ctx context.Context, canvasBounds image.Rec
 
 	setCache := true
 
-	logoWidth += int(float64(bounds.Dx()) * scrollLogoBufferRatio)
+	if s.config.ScrollMode.Load() {
+		logoWidth += int(float64(bounds.Dx()) * scrollLogoBufferRatio)
+	}
+
 	if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
 		recordAdder, err = s.getTeamInfoWidth(s.api.League(), abbreviation)
 		if err != nil {

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -607,12 +607,6 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 					return nil, nil, err
 				}
 
-				/*
-					if s.hasNoInfo(rank, record, oddStr, underDog, leftTeam.GetAbbreviation()) {
-						return writer, []string{rank, record}, nil
-					}
-				*/
-
 				widthStrs := []string{}
 				if s.config.ShowRecord.Load() {
 					widthStrs = append(widthStrs, rank, record)

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -673,10 +673,6 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 				rank := text[0]
 				record := text[1]
 
-				if s.hasNoInfo(rank, record, oddStr, underDog, leftTeam.GetAbbreviation()) {
-					return nil
-				}
-
 				if rank != "" && s.config.ShowRecord.Load() {
 					_ = writer.WriteAlignedBoxed(
 						rgbrender.RightTop,
@@ -719,12 +715,6 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 				if err != nil {
 					return nil, nil, err
 				}
-
-				/*
-					if s.hasNoInfo(rank, record, oddStr, underDog, rightTeam.GetAbbreviation()) {
-						return writer, []string{rank, record}, nil
-					}
-				*/
 
 				widthStrs := []string{}
 				if s.config.ShowRecord.Load() {
@@ -792,10 +782,6 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 				rank := text[0]
 				record := text[1]
 
-				if s.hasNoInfo(rank, record, oddStr, underDog, rightTeam.GetAbbreviation()) {
-					return nil
-				}
-
 				if rank != "" && s.config.ShowRecord.Load() {
 					_ = writer.WriteAlignedBoxed(
 						rgbrender.LeftTop,
@@ -830,23 +816,6 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 			},
 		),
 	}, nil
-}
-
-func (s *SportBoard) hasNoInfo(rank string, record string, odds string, underDog string, thisTeam string) bool {
-	if (s.config.ShowRecord.Load() && rank == "" && record == "") && (s.config.GamblingSpread.Load() && odds == "") {
-		return true
-	}
-	if !s.config.ShowRecord.Load() && (s.config.GamblingSpread.Load() && odds == "") {
-		return true
-	}
-	if !s.config.GamblingSpread.Load() && s.config.ShowRecord.Load() && rank == "" && record == "" {
-		return true
-	}
-	if !s.config.ShowRecord.Load() && s.config.GamblingSpread.Load() && strings.EqualFold(underDog, thisTeam) {
-		return true
-	}
-
-	return false
 }
 
 func (s *SportBoard) renderNoScheduled(ctx context.Context, canvas board.Canvas) error {

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -601,23 +601,12 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 					return nil, nil, err
 				}
 
-				if s.hasNoInfo(rank, record, oddStr, underDog, leftTeam.GetAbbreviation()) {
-					return writer, []string{rank, record}, nil
-				}
+				/*
+					if s.hasNoInfo(rank, record, oddStr, underDog, leftTeam.GetAbbreviation()) {
+						return writer, []string{rank, record}, nil
+					}
+				*/
 
-				if !s.config.ScrollMode.Load() {
-					s.log.Debug("set team info width 0",
-						zap.String("league", s.api.League()),
-						zap.String("team", leftTeam.GetAbbreviation()),
-					)
-					s.setTeamInfoWidth(s.api.League(), leftTeam.GetAbbreviation(), 0)
-					maxX := (leftBounds.Bounds().Dx() - s.textAreaWidth(leftBounds)) / 2
-					leftBounds = image.Rect(leftBounds.Min.X, leftBounds.Min.Y, maxX, leftBounds.Max.Y)
-
-					return writer, []string{rank, record}, nil
-				}
-
-				// Scroll mode
 				widthStrs := []string{}
 				if s.config.ShowRecord.Load() {
 					widthStrs = append(widthStrs, rank, record)
@@ -625,6 +614,31 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 				if s.config.GamblingSpread.Load() {
 					widthStrs = append(widthStrs, oddStr)
 				}
+
+				if !s.config.ScrollMode.Load() {
+					w := 0
+					if float32(z.Dx())/float32(z.Dy()) > 2.0 {
+						var err error
+						w, err = s.calculateTeamInfoWidth(canvas, writer, widthStrs)
+						if err != nil {
+							s.log.Error("failed to calculate team info width, using default",
+								zap.Error(err),
+							)
+						}
+					}
+					s.log.Debug("set team info width",
+						zap.Int("width", w),
+						zap.String("league", s.api.League()),
+						zap.String("team", leftTeam.GetAbbreviation()),
+					)
+					s.setTeamInfoWidth(s.api.League(), leftTeam.GetAbbreviation(), w)
+					maxX := (leftBounds.Bounds().Dx() - s.textAreaWidth(leftBounds)) / 2
+					leftBounds = image.Rect(leftBounds.Min.X, leftBounds.Min.Y, maxX, leftBounds.Max.Y)
+
+					return writer, []string{rank, record}, nil
+				}
+
+				// Scroll mode
 				infoWidth, err := s.getTeamInfoWidth(s.api.League(), leftTeam.GetAbbreviation())
 				if err != nil || infoWidth == 0 {
 					var err error
@@ -706,19 +720,12 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 					return nil, nil, err
 				}
 
-				if s.hasNoInfo(rank, record, oddStr, underDog, rightTeam.GetAbbreviation()) {
-					return writer, []string{rank, record}, nil
-				}
+				/*
+					if s.hasNoInfo(rank, record, oddStr, underDog, rightTeam.GetAbbreviation()) {
+						return writer, []string{rank, record}, nil
+					}
+				*/
 
-				if !s.config.ScrollMode.Load() {
-					s.setTeamInfoWidth(s.api.League(), rightTeam.GetAbbreviation(), 0)
-					minX := ((rightBounds.Bounds().Dx() - s.textAreaWidth(rightBounds)) / 2) + s.textAreaWidth(rightBounds)
-					rightBounds = image.Rect(minX, rightBounds.Min.Y, rightBounds.Max.X, rightBounds.Max.Y)
-
-					return writer, []string{rank, record}, nil
-				}
-
-				// Scroll mode
 				widthStrs := []string{}
 				if s.config.ShowRecord.Load() {
 					widthStrs = append(widthStrs, rank, record)
@@ -726,6 +733,31 @@ func (s *SportBoard) teamInfoLayers(canvas draw.Image, liveGame Game, bounds ima
 				if s.config.GamblingSpread.Load() {
 					widthStrs = append(widthStrs, oddStr)
 				}
+
+				if !s.config.ScrollMode.Load() {
+					w := 0
+					if float32(z.Dx())/float32(z.Dy()) > 2.0 {
+						var err error
+						w, err = s.calculateTeamInfoWidth(canvas, writer, widthStrs)
+						if err != nil {
+							s.log.Error("failed to calculate team info width, using default",
+								zap.Error(err),
+							)
+						}
+					}
+					s.log.Debug("set team info width",
+						zap.Int("width", w),
+						zap.String("league", s.api.League()),
+						zap.String("team", rightTeam.GetAbbreviation()),
+					)
+					s.setTeamInfoWidth(s.api.League(), rightTeam.GetAbbreviation(), w)
+					minX := ((rightBounds.Bounds().Dx() - s.textAreaWidth(rightBounds)) / 2) + s.textAreaWidth(rightBounds)
+					rightBounds = image.Rect(minX, rightBounds.Min.Y, rightBounds.Max.X, rightBounds.Max.Y)
+
+					return writer, []string{rank, record}, nil
+				}
+
+				// Scroll mode
 				infoWidth, err := s.getTeamInfoWidth(s.api.League(), rightTeam.GetAbbreviation())
 				if err != nil || infoWidth == 0 {
 					var err error

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -21,7 +21,13 @@ const (
 	teamInfoPad         = 2
 )
 
-var red = color.RGBA{255, 0, 0, 255}
+var (
+	red                  = color.RGBA{255, 0, 0, 255}
+	infoLayerPriority    = rgbrender.BackgroundPriority + 1
+	counterLayerPriority = rgbrender.ForegroundPriority
+	scoreLayerPriority   = rgbrender.BackgroundPriority + 2
+	logoLayerPriority    = rgbrender.BackgroundPriority
+)
 
 func (s *SportBoard) homeSide() side {
 	if s.api.League() == mls {
@@ -90,7 +96,7 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 			return err
 		}
 		for _, i := range infos {
-			layers.AddTextLayer(rgbrender.ForegroundPriority, i)
+			layers.AddTextLayer(infoLayerPriority, i)
 		}
 	}
 
@@ -107,10 +113,10 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 		}
 
 		for _, l := range logos {
-			layers.AddLayer(rgbrender.BackgroundPriority, l)
+			layers.AddLayer(logoLayerPriority, l)
 		}
 
-		layers.AddTextLayer(rgbrender.BackgroundPriority+1,
+		layers.AddTextLayer(scoreLayerPriority,
 			rgbrender.NewTextLayer(
 				func(ctx context.Context) (*rgbrender.TextWriter, []string, error) {
 					quarter, err := liveGame.GetQuarter()
@@ -141,7 +147,7 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 			),
 		)
 
-		layers.AddTextLayer(rgbrender.BackgroundPriority+1,
+		layers.AddTextLayer(scoreLayerPriority,
 			rgbrender.NewTextLayer(
 				func(ctx context.Context) (*rgbrender.TextWriter, []string, error) {
 					writer, err := s.getScoreWriter(canvas.Bounds())
@@ -240,7 +246,7 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 		)
 
 		if counter != nil {
-			layers.AddLayer(rgbrender.ForegroundPriority, counterLayer(counter))
+			layers.AddLayer(counterLayerPriority, counterLayer(counter))
 		}
 
 		if err := layers.Draw(ctx, canvas); err != nil {
@@ -295,13 +301,17 @@ func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas board.Canvas
 		return err
 	}
 
+	if counter != nil {
+		layers.AddLayer(counterLayerPriority, counterLayer(counter))
+	}
+
 	if s.config.ShowRecord.Load() || s.config.GamblingSpread.Load() {
 		infos, err := s.teamInfoLayers(canvas, liveGame, canvas.Bounds())
 		if err != nil {
 			return err
 		}
 		for _, i := range infos {
-			layers.AddTextLayer(rgbrender.ForegroundPriority, i)
+			layers.AddTextLayer(infoLayerPriority, i)
 		}
 	}
 
@@ -311,10 +321,10 @@ func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas board.Canvas
 	}
 
 	for _, l := range logos {
-		layers.AddLayer(rgbrender.BackgroundPriority, l)
+		layers.AddLayer(logoLayerPriority, l)
 	}
 
-	layers.AddTextLayer(rgbrender.BackgroundPriority+1,
+	layers.AddTextLayer(scoreLayerPriority,
 		rgbrender.NewTextLayer(
 			func(ctx context.Context) (*rgbrender.TextWriter, []string, error) {
 				timeWriter, err := s.getTimeWriter(canvas.Bounds())
@@ -346,7 +356,7 @@ func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas board.Canvas
 			},
 		),
 	)
-	layers.AddTextLayer(rgbrender.BackgroundPriority+1,
+	layers.AddTextLayer(scoreLayerPriority,
 		rgbrender.NewTextLayer(
 			func(ctx context.Context) (*rgbrender.TextWriter, []string, error) {
 				scoreWriter, err := s.getScoreWriter(canvas.Bounds())
@@ -367,10 +377,6 @@ func (s *SportBoard) renderUpcomingGame(ctx context.Context, canvas board.Canvas
 			},
 		),
 	)
-
-	if counter != nil {
-		layers.AddLayer(rgbrender.ForegroundPriority, counterLayer(counter))
-	}
 
 	select {
 	case <-ctx.Done():
@@ -393,7 +399,7 @@ func (s *SportBoard) renderCompleteGame(ctx context.Context, canvas board.Canvas
 			return err
 		}
 		for _, i := range infos {
-			layers.AddTextLayer(rgbrender.ForegroundPriority, i)
+			layers.AddTextLayer(infoLayerPriority, i)
 		}
 	}
 
@@ -404,10 +410,10 @@ func (s *SportBoard) renderCompleteGame(ctx context.Context, canvas board.Canvas
 	}
 
 	for _, l := range logos {
-		layers.AddLayer(rgbrender.BackgroundPriority, l)
+		layers.AddLayer(logoLayerPriority, l)
 	}
 
-	layers.AddTextLayer(rgbrender.BackgroundPriority+1,
+	layers.AddTextLayer(scoreLayerPriority,
 		rgbrender.NewTextLayer(
 			func(ctx context.Context) (*rgbrender.TextWriter, []string, error) {
 				writer, err := s.getTimeWriter(canvas.Bounds())
@@ -429,7 +435,7 @@ func (s *SportBoard) renderCompleteGame(ctx context.Context, canvas board.Canvas
 		),
 	)
 
-	layers.AddTextLayer(rgbrender.BackgroundPriority+1,
+	layers.AddTextLayer(scoreLayerPriority,
 		rgbrender.NewTextLayer(
 			func(ctx context.Context) (*rgbrender.TextWriter, []string, error) {
 				isFavorite, err := s.isFavoriteGame(liveGame)
@@ -467,7 +473,7 @@ func (s *SportBoard) renderCompleteGame(ctx context.Context, canvas board.Canvas
 	)
 
 	if counter != nil {
-		layers.AddLayer(rgbrender.ForegroundPriority, counterLayer(counter))
+		layers.AddLayer(counterLayerPriority, counterLayer(counter))
 	}
 
 	return layers.Draw(ctx, canvas)

--- a/script/shell.console
+++ b/script/shell.console
@@ -17,6 +17,7 @@ if [ "${IN_DOCKER}" = "no" ]; then
     -e IN_DOCKER=yes \
     -v "${ROOT}":/src \
     -v /tmp:/tmp \
+    -v "${ROOT}/matrix.conf":/etc/sportsmatrix.conf \
     -w /src \
     -p 8080:8080 \
     ${pibuilder} \

--- a/script/shell.console
+++ b/script/shell.console
@@ -17,7 +17,6 @@ if [ "${IN_DOCKER}" = "no" ]; then
     -e IN_DOCKER=yes \
     -v "${ROOT}":/src \
     -v /tmp:/tmp \
-    -v "${ROOT}/matrix.conf":/etc/sportsmatrix.conf \
     -w /src \
     -p 8080:8080 \
     ${pibuilder} \


### PR DESCRIPTION
This improves the layout of non-scroll mode on wide matrix setups- it uses the entire screen rather than compressing the info as if it were a narrower (like 64 pix) screen.

Also does some layer shuffling to ensure the game counter at the bottom doesn't sometimes get drawn over by team record.

Oh, and go v1.17