### PR TITLE
Fix odds spacing, reduce API schedule calls

### DIFF
--- a/pkg/espnboard/games.go
+++ b/pkg/espnboard/games.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	overUnderRegex = regexp.MustCompile(`^([A-Z]+)\s+([-]{0,1}[0-9]+[\.0-9]*)`)
-	mLB            = "MLB"
+	overUnderRegex   = regexp.MustCompile(`^([A-Z]+)\s+([-]{0,1}[0-9]+[\.0-9]*)`)
+	mLB              = "MLB"
+	scheduleAPILimit = 30 * time.Second
 )
 
 type schedule struct {
@@ -254,10 +255,11 @@ func (e *ESPNBoard) GetGames(ctx context.Context, dateStr string) ([]*Game, erro
 		e.lastScheduleCall[dateStr] = &t
 	} else {
 		// Make sure we don't hammer this API if it has failures
-		if time.Now().Local().Before(t.Add(1 * time.Minute)) {
+		if time.Now().Local().Before(t.Add(scheduleAPILimit)) {
 			e.log.Error("tried calling ESPN scoreboard API too quickly",
 				zap.Time("last call", *t),
 				zap.String("date", dateStr),
+				zap.String("league", e.League()),
 			)
 			return nil, fmt.Errorf("called scoreboard API too quickly")
 		}

--- a/pkg/sportboard/sportboard.go
+++ b/pkg/sportboard/sportboard.go
@@ -388,6 +388,13 @@ func (s *SportBoard) Render(ctx context.Context, canvas board.Canvas) error {
 		return err
 	}
 
+	if len(allGames) < 1 {
+		s.log.Debug("no games scheduled",
+			zap.String("league", s.api.League()),
+		)
+		return nil
+	}
+
 	if _, err := s.api.GetTeams(ctx); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes spacing issue when odds are displayed. 

Reduces excessive calls to the schedule API for espnboard.

If a logo fails to render, does not prevent the game from appearing on screen.