### PR TITLE
Fix missing-logo team name for right side

### DIFF
--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -583,7 +583,7 @@ func (s *SportBoard) logoLayers(liveGame Game, bounds image.Rectangle) ([]*rgbre
 						rgbrender.RightCenter,
 						canvas,
 						rgbrender.ZeroedBounds(bounds),
-						[]string{leftTeam.GetAbbreviation()},
+						[]string{rightTeam.GetAbbreviation()},
 						color.White,
 					)
 					return nil


### PR DESCRIPTION
Fixes the wrong team name in right-side of scoreboard when logo is missing, from https://github.com/robbydyer/sports/issues/126