### PR TITLE
Handle null stock prices

### DIFF
--- a/pkg/stockboard/render.go
+++ b/pkg/stockboard/render.go
@@ -176,7 +176,6 @@ func (s *StockBoard) getChart(bounds image.Rectangle, stock *Stock, prices []*Pr
 			for thisY := y; thisY <= midY; thisY++ {
 				if thisY == y {
 					img.Set(x, thisY, green)
-
 				} else {
 					img.Set(x, thisY, lightGreen)
 				}

--- a/pkg/stockboard/render.go
+++ b/pkg/stockboard/render.go
@@ -153,7 +153,7 @@ func (s *StockBoard) getChart(bounds image.Rectangle, stock *Stock, prices []*Pr
 			}
 		}
 
-		if bounds.Dx()/resolution != bounds.Dx() {
+		if bounds.Dx()/resolution != bounds.Dx() && resolution > 1 {
 			fillChartGaps(img, midY, image.Pt(lastX, lastY), image.Pt(x, y))
 		}
 
@@ -166,14 +166,22 @@ func (s *StockBoard) getChart(bounds image.Rectangle, stock *Stock, prices []*Pr
 
 		if y > midY {
 			for thisY := y; thisY > midY; thisY-- {
-				img.Set(x, thisY, red)
+				if thisY == y {
+					img.Set(x, thisY, red)
+				} else {
+					img.Set(x, thisY, lightRed)
+				}
 			}
 		} else {
 			for thisY := y; thisY <= midY; thisY++ {
-				img.Set(x, thisY, green)
+				if thisY == y {
+					img.Set(x, thisY, green)
+
+				} else {
+					img.Set(x, thisY, lightGreen)
+				}
 			}
 		}
-
 		lastY = y
 	}
 
@@ -203,11 +211,19 @@ func fillChartGaps(img draw.Image, midY int, previous image.Point, current image
 	for thisX := x - 1; thisX > lastX; thisX-- {
 		if thisY <= midY {
 			for myY := thisY; myY <= midY; myY++ {
-				img.Set(thisX, myY, green)
+				if myY == thisY {
+					img.Set(thisX, myY, green)
+				} else {
+					img.Set(thisX, myY, lightGreen)
+				}
 			}
 		} else {
 			for myY := thisY; myY > midY; myY-- {
-				img.Set(thisX, myY, red)
+				if myY == thisY {
+					img.Set(thisX, myY, red)
+				} else {
+					img.Set(thisX, myY, lightRed)
+				}
 			}
 		}
 		thisY = thisY + (multiplier * fill)

--- a/pkg/stockboard/stockboard.go
+++ b/pkg/stockboard/stockboard.go
@@ -19,8 +19,10 @@ import (
 )
 
 var (
-	red   = color.RGBA{255, 0, 0, 255}
-	green = color.RGBA{0, 255, 0, 255}
+	red        = color.RGBA{255, 0, 0, 255}
+	green      = color.RGBA{0, 255, 0, 255}
+	lightGreen = color.NRGBA{0, 255, 0, 50}
+	lightRed   = color.NRGBA{255, 0, 0, 50}
 )
 
 // StockBoard displays stocks

--- a/pkg/stockboard/util_test.go
+++ b/pkg/stockboard/util_test.go
@@ -268,7 +268,23 @@ func TestGetChartPrices(t *testing.T) {
 						Price: 0.0,
 					},
 					{
+						Time:  now.Add(6 * time.Minute),
+						Price: 0.0,
+					},
+					{
+						Time:  now.Add(7 * time.Minute),
+						Price: 0.0,
+					},
+					{
 						Time:  now.Add(15 * time.Minute),
+						Price: 1.0,
+					},
+					{
+						Time:  now.Add(16 * time.Minute),
+						Price: 1.0,
+					},
+					{
+						Time:  now.Add(17 * time.Minute),
 						Price: 1.0,
 					},
 					{

--- a/pkg/yahoo/yahoo.go
+++ b/pkg/yahoo/yahoo.go
@@ -195,7 +195,7 @@ func (a *API) stockFromData(data *chartDat) (*stockboard.Stock, error) {
 		t := time.Unix(ts, 0)
 
 		price := c.Indicators.Quote[0].Close[i]
-		// If price doesn't change from previos period, it returns as `null`
+		// If price doesn't change from previous period, it returns as `null`
 		if price == nil {
 			price = fltPtr(lastPrice)
 		} else {

--- a/pkg/yahoo/yahoo.go
+++ b/pkg/yahoo/yahoo.go
@@ -41,7 +41,7 @@ type chartDat struct {
 			Timestamp  []int64 `json:"timestamp"`
 			Indicators *struct {
 				Quote []*struct {
-					Close []float64 `json:"close"`
+					Close []*float64 `json:"close"`
 				} `json:"quote"`
 			} `json:"indicators"`
 		} `json:"result"`
@@ -186,12 +186,25 @@ func (a *API) stockFromData(data *chartDat) (*stockboard.Stock, error) {
 
 	s.Change = ((s.Price - s.OpenPrice) / s.OpenPrice) * 100.0
 
+	fltPtr := func(f float64) *float64 {
+		return &f
+	}
+
+	lastPrice := s.OpenPrice
 	for i, ts := range c.Timestamp {
 		t := time.Unix(ts, 0)
 
+		price := c.Indicators.Quote[0].Close[i]
+		// If price doesn't change from previos period, it returns as `null`
+		if price == nil {
+			price = fltPtr(lastPrice)
+		} else {
+			lastPrice = *price
+		}
+
 		p := &stockboard.Price{
 			Time:  t,
-			Price: c.Indicators.Quote[0].Close[i],
+			Price: *price,
 		}
 
 		a.log.Debug("add price",

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -624,11 +624,12 @@ stocksConfig:
   - ^IXIC
   # DOW
   - ^DJI
+  - GME
 
   # The number of price points to use in rendering the chart.
   # This number should be between 1 and the width of your matrix (i.e. 64).
   # Larger numbers *might* improve performance on lower-powered Pi's.
-  chartResolution: 1
+  chartResolution: 4
 
   # Delay between each ticker
   boardDelay: "10s"


### PR DESCRIPTION
This better handles `null` prices for stocks, which indicate the price hasn't changed. This should help smooth out the graphs. Also, adjusting colors and setting default chart resolution to 4, since it smooths graph out.