### PR TITLE
Fix image scaling that causes image artifacts

### DIFF
--- a/cmd/sportsmatrix/main.go
+++ b/cmd/sportsmatrix/main.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	yaml "github.com/ghodss/yaml"
-	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/atomic"
@@ -590,7 +589,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 	}
 
 	if r.config.ImageConfig != nil {
-		b, err := imageboard.New(afero.NewOsFs(), r.config.ImageConfig, logger)
+		b, err := imageboard.New(r.config.ImageConfig, logger)
 		if err != nil {
 			return boards, err
 		}

--- a/cmd/sportsmatrix/run.go
+++ b/cmd/sportsmatrix/run.go
@@ -104,7 +104,7 @@ func (s *runCmd) run(cmd *cobra.Command, args []string) error {
 	defer mtrx.Close()
 
 	for _, b := range boards {
-		if strings.EqualFold(b.Name(), "img") {
+		if strings.EqualFold(b.Name(), imageboard.Name) {
 			if i, ok := b.(*imageboard.ImageBoard); ok {
 				i.SetJumper(mtrx.JumpTo)
 			}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pseudomuto/protoc-gen-doc v1.5.0
 	github.com/robbydyer/exp v0.1.2
 	github.com/robfig/cron/v3 v3.0.1
-	github.com/spf13/afero v1.8.0
+	github.com/spf13/afero v1.8.0 // indirect
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 	github.com/srikrsna/protoc-gen-gotag v0.6.2

--- a/pkg/imageboard/imageboard.go
+++ b/pkg/imageboard/imageboard.go
@@ -29,7 +29,7 @@ const (
 	diskCacheDir = "/tmp/sportsmatrix_logos/imageboard"
 
 	// Name is the board name
-	Name = "img"
+	Name = "Img"
 )
 
 var preloaderTimeout = (20 * time.Second)

--- a/pkg/imageboard/imageboard.go
+++ b/pkg/imageboard/imageboard.go
@@ -6,15 +6,14 @@ import (
 	"image"
 	"image/draw"
 	"image/gif"
-	"image/png"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/disintegration/imaging"
 	"github.com/robfig/cron/v3"
-	"github.com/spf13/afero"
 	"github.com/twitchtv/twirp"
 	"go.uber.org/atomic"
 	"go.uber.org/zap"
@@ -23,10 +22,12 @@ import (
 	"github.com/robbydyer/sports/pkg/board"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 	"github.com/robbydyer/sports/pkg/twirphelpers"
+	"github.com/robbydyer/sports/pkg/util"
 )
 
 const (
-	diskCacheDir = "/tmp/sportsmatrix/imageboard"
+	diskCacheDir = "/tmp/sportsmatrix_logos/imageboard"
+	Name         = "img"
 )
 
 var preloaderTimeout = (20 * time.Second)
@@ -38,7 +39,6 @@ type Jumper func(ctx context.Context, boardName string) error
 type ImageBoard struct {
 	config         *Config
 	log            *zap.Logger
-	fs             afero.Fs
 	imageCache     map[string]image.Image
 	gifCacheLock   sync.Mutex
 	gifCache       map[string]*gif.GIF
@@ -102,14 +102,10 @@ func (c *Config) SetDefaults() {
 }
 
 // New ...
-func New(fs afero.Fs, config *Config, logger *zap.Logger) (*ImageBoard, error) {
-	if fs == nil {
-		fs = afero.NewOsFs()
-	}
+func New(config *Config, logger *zap.Logger) (*ImageBoard, error) {
 	i := &ImageBoard{
 		config:         config,
 		log:            logger,
-		fs:             fs,
 		imageCache:     make(map[string]image.Image),
 		gifCache:       make(map[string]*gif.GIF),
 		lockers:        make(map[string]*sync.Mutex),
@@ -177,7 +173,7 @@ func (i *ImageBoard) cacheClear() {
 
 // Name ...
 func (i *ImageBoard) Name() string {
-	return "Img"
+	return Name
 }
 
 // Enabled ...
@@ -267,8 +263,7 @@ func (i *ImageBoard) Render(ctx context.Context, canvas board.Canvas) error {
 	for _, dir := range i.config.Directories {
 		i.log.Debug("walking directory", zap.String("directory", dir))
 
-		err := afero.Walk(i.fs, dir, dirWalker(false))
-		if err != nil {
+		if err := filepath.Walk(dir, dirWalker(false)); err != nil {
 			i.log.Error("failed to prepare image for board", zap.Error(err))
 		}
 	}
@@ -278,7 +273,7 @@ func (i *ImageBoard) Render(ctx context.Context, canvas board.Canvas) error {
 			zap.String("directory", dir.Directory),
 		)
 
-		if err := afero.Walk(i.fs, dir.Directory, dirWalker(dir.JumpOnly)); err != nil {
+		if err := filepath.Walk(dir.Directory, dirWalker(dir.JumpOnly)); err != nil {
 			i.log.Error("failed to prepare image walking directory list",
 				zap.Error(err),
 			)
@@ -544,7 +539,11 @@ func cacheKey(path string, bounds image.Rectangle) string {
 
 func (i *ImageBoard) cachedFile(baseName string, bounds image.Rectangle) string {
 	parts := strings.Split(baseName, ".")
-	n := fmt.Sprintf("%s_%dx%d.%s", strings.Join(parts[0:len(parts)-1], "."), bounds.Dx(), bounds.Dy(), parts[len(parts)-1])
+	suffix := "tiff"
+	if strings.EqualFold(parts[len(parts)-1], "gif") {
+		suffix = "gif"
+	}
+	n := fmt.Sprintf("%s_%dx%d.%s", strings.Join(parts[0:len(parts)-1], "."), bounds.Dx(), bounds.Dy(), suffix)
 	return filepath.Join(diskCacheDir, n)
 }
 
@@ -587,9 +586,9 @@ func (i *ImageBoard) getSizedImage(path string, bounds image.Rectangle, preloade
 
 	if i.config.UseDiskCache.Load() {
 		i.log.Debug("checking for cached file", zap.String("file", cachedFile))
-		if exists, err := afero.Exists(i.fs, cachedFile); err == nil && exists {
+		if exists, err := util.FileExists(cachedFile); err == nil && exists {
 			i.log.Debug("cached file exists", zap.String("file", cachedFile))
-			img, err := i.getSizedImageDiskCache(cachedFile)
+			img, err := imaging.Open(cachedFile)
 			if err != nil {
 				return nil, err
 			}
@@ -604,16 +603,11 @@ func (i *ImageBoard) getSizedImage(path string, bounds image.Rectangle, preloade
 		}
 	}
 
-	f, err := i.fs.Open(path)
+	img, err := imaging.Open(path)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open image: %w", err)
 	}
-	defer f.Close()
 
-	img, _, err := image.Decode(f)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode image: %w", err)
-	}
 	// Resize to matrix bounds
 	i.log.Debug("resizing image",
 		zap.String("name", path),
@@ -623,8 +617,10 @@ func (i *ImageBoard) getSizedImage(path string, bounds image.Rectangle, preloade
 	sizedImg := rgbrender.ResizeImage(img, bounds, 1)
 
 	if i.config.UseDiskCache.Load() {
-		if err := rgbrender.SavePngAfero(i.fs, sizedImg, cachedFile); err != nil {
-			i.log.Error("failed to save resized PNG to disk", zap.Error(err))
+		if err := imaging.Save(sizedImg, cachedFile); err != nil {
+			i.log.Error("failed to save resized image to disk",
+				zap.Error(err),
+			)
 		}
 	}
 
@@ -675,7 +671,7 @@ func (i *ImageBoard) getSizedGIF(ctx context.Context, path string, bounds image.
 
 	if i.config.UseDiskCache.Load() {
 		i.log.Debug("checking for cached file", zap.String("file", cachedFile))
-		if exists, err := afero.Exists(i.fs, cachedFile); err == nil && exists {
+		if exists, err := util.FileExists(cachedFile); err == nil && exists {
 			g, err := i.getSizedGIFDiskCache(cachedFile)
 			if err != nil {
 				return nil, err
@@ -688,7 +684,7 @@ func (i *ImageBoard) getSizedGIF(ctx context.Context, path string, bounds image.
 		}
 	}
 
-	f, err := i.fs.Open(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
@@ -715,7 +711,7 @@ func (i *ImageBoard) getSizedGIF(ctx context.Context, path string, bounds image.
 
 	if i.config.UseDiskCache.Load() {
 		i.log.Debug("saving resized GIF", zap.String("filename", cachedFile))
-		if err := rgbrender.SaveGifAfero(i.fs, g, cachedFile); err != nil {
+		if err := rgbrender.SaveGif(g, cachedFile); err != nil {
 			i.log.Error("failed to save resized GIF to disk", zap.Error(err))
 		}
 	}
@@ -728,7 +724,7 @@ func (i *ImageBoard) getSizedGIF(ctx context.Context, path string, bounds image.
 }
 
 func (i *ImageBoard) getSizedGIFDiskCache(path string) (*gif.GIF, error) {
-	f, err := i.fs.Open(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open cached GIF image: %w", err)
 	}
@@ -742,40 +738,6 @@ func (i *ImageBoard) getSizedGIFDiskCache(path string) (*gif.GIF, error) {
 	return g, nil
 }
 
-func (i *ImageBoard) getSizedImageDiskCache(path string) (image.Image, error) {
-	f, err := i.fs.Open(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open cached image: %w", err)
-	}
-	defer f.Close()
-
-	if strings.HasSuffix(strings.ToLower(path), ".png") {
-		img, err := png.Decode(f)
-		if err != nil {
-			return nil, err
-		}
-
-		i.log.Debug("got PNG from disk cache",
-			zap.String("path", path),
-			zap.String("size", fmt.Sprintf("%dx%d", img.Bounds().Dx(), img.Bounds().Dy())),
-		)
-
-		return img, nil
-	}
-
-	img, _, err := image.Decode(f)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode image: %w", err)
-	}
-
-	i.log.Debug("got non-png from disk cache",
-		zap.String("path", path),
-		zap.String("size", fmt.Sprintf("%dx%d", img.Bounds().Dx(), img.Bounds().Dy())),
-	)
-
-	return img, nil
-}
-
 // HasPriority ...
 func (i *ImageBoard) HasPriority() bool {
 	return false
@@ -783,7 +745,7 @@ func (i *ImageBoard) HasPriority() bool {
 
 func (i *ImageBoard) validateDirectories() error {
 	for _, dir := range i.config.Directories {
-		exists, err := afero.DirExists(i.fs, dir)
+		exists, err := util.FileExists(dir)
 		if err != nil {
 			return err
 		}

--- a/pkg/imageboard/imageboard.go
+++ b/pkg/imageboard/imageboard.go
@@ -27,7 +27,9 @@ import (
 
 const (
 	diskCacheDir = "/tmp/sportsmatrix_logos/imageboard"
-	Name         = "img"
+
+	// Name is the board name
+	Name = "img"
 )
 
 var preloaderTimeout = (20 * time.Second)

--- a/pkg/imageboard/server.go
+++ b/pkg/imageboard/server.go
@@ -30,6 +30,8 @@ func (s *Server) SetStatus(ctx context.Context, req *pb.SetStatusReq) (*emptypb.
 	}
 
 	s.board.config.Enabled.Store(req.Status.Enabled)
+	s.board.config.UseDiskCache.Store(req.Status.DiskcacheEnabled)
+	s.board.config.UseMemCache.Store(req.Status.MemcacheEnabled)
 
 	return &emptypb.Empty{}, nil
 }
@@ -38,7 +40,9 @@ func (s *Server) SetStatus(ctx context.Context, req *pb.SetStatusReq) (*emptypb.
 func (s *Server) GetStatus(ctx context.Context, req *emptypb.Empty) (*pb.StatusResp, error) {
 	return &pb.StatusResp{
 		Status: &pb.Status{
-			Enabled: s.board.config.Enabled.Load(),
+			Enabled:          s.board.config.Enabled.Load(),
+			DiskcacheEnabled: s.board.config.UseDiskCache.Load(),
+			MemcacheEnabled:  s.board.config.UseMemCache.Load(),
 		},
 	}, nil
 }

--- a/pkg/logo/logo.go
+++ b/pkg/logo/logo.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/disintegration/imaging"
+
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 

--- a/pkg/logo/logo.go
+++ b/pkg/logo/logo.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"image"
 	"image/draw"
-	"image/png"
 	"os"
 	"path/filepath"
 
 	"go.uber.org/zap"
 
+	"github.com/disintegration/imaging"
 	"github.com/robbydyer/sports/pkg/rgbrender"
 )
 
@@ -75,7 +75,7 @@ func (l *Logo) ensureLogger() {
 
 // ThumbnailFilename returns the filname for the resized thumbnail to use
 func (l *Logo) ThumbnailFilename(size image.Rectangle) string {
-	return filepath.Join(l.targetDirectory, fmt.Sprintf("%s.png", l.key))
+	return filepath.Join(l.targetDirectory, fmt.Sprintf("%s.tiff", l.key))
 }
 
 // GetThumbnail returns the resized image
@@ -121,8 +121,8 @@ func (l *Logo) GetThumbnail(ctx context.Context, size image.Rectangle) (image.Im
 			go func() {
 				l.ensureLogger()
 				l.log.Info("saving thumbnail logo", zap.String("filename", thumbFile))
-				if err := rgbrender.SavePng(l.thumbnail, thumbFile); err != nil {
-					l.log.Error("failed to save logo PNG", zap.Error(err))
+				if err := imaging.Save(l.thumbnail, thumbFile); err != nil {
+					l.log.Error("failed to save logo to file", zap.Error(err))
 				}
 			}()
 
@@ -132,15 +132,10 @@ func (l *Logo) GetThumbnail(ctx context.Context, size image.Rectangle) (image.Im
 		return nil, err
 	}
 
-	t, err := os.Open(thumbFile)
+	var err error
+	l.thumbnail, err = imaging.Open(thumbFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to open logo %s: %w", thumbFile, err)
-	}
-	defer t.Close()
-
-	l.thumbnail, err = png.Decode(t)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode logo %s: %w", thumbFile, err)
 	}
 
 	return l.thumbnail, nil

--- a/pkg/rgbrender/img.go
+++ b/pkg/rgbrender/img.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/disintegration/imaging"
 	"github.com/nfnt/resize"
-	"github.com/spf13/afero"
 
 	"github.com/robbydyer/sports/pkg/board"
 )
@@ -64,31 +63,6 @@ func SavePng(img image.Image, fileName string) error {
 // SaveGif ...
 func SaveGif(img *gif.GIF, fileName string) error {
 	f, err := os.Create(fileName)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	return gif.EncodeAll(f, img)
-}
-
-// SavePngAfero ...
-func SavePngAfero(fs afero.Fs, img image.Image, fileName string) error {
-	if img == nil {
-		return fmt.Errorf("cannot save nil image.Image as PNG")
-	}
-	f, err := fs.Create(fileName)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	return imaging.Encode(f, img, imaging.PNG, imaging.PNGCompressionLevel(png.NoCompression))
-}
-
-// SaveGifAfero ...
-func SaveGifAfero(fs afero.Fs, img *gif.GIF, fileName string) error {
-	f, err := fs.Create(fileName)
 	if err != nil {
 		return err
 	}

--- a/pkg/rgbrender/img.go
+++ b/pkg/rgbrender/img.go
@@ -58,13 +58,7 @@ func SavePng(img image.Image, fileName string) error {
 	if img == nil {
 		return fmt.Errorf("cannot save nil image.Image as PNG")
 	}
-	f, err := os.Create(fileName)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	return png.Encode(f, img)
+	return imaging.Save(img, fileName, imaging.PNGCompressionLevel(png.NoCompression))
 }
 
 // SaveGif ...
@@ -89,7 +83,7 @@ func SavePngAfero(fs afero.Fs, img image.Image, fileName string) error {
 	}
 	defer f.Close()
 
-	return png.Encode(f, img)
+	return imaging.Encode(f, img, imaging.PNG, imaging.PNGCompressionLevel(png.NoCompression))
 }
 
 // SaveGifAfero ...

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/png"
 	"net/http"
+	"os"
 	"time"
 )
 
@@ -117,4 +118,17 @@ func PullPng(ctx context.Context, url string) (image.Image, error) {
 	}
 
 	return png.Decode(resp.Body)
+}
+
+// FileExists ...
+func FileExists(fileName string) (bool, error) {
+	_, err := os.Stat(fileName)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	return true, nil
 }


### PR DESCRIPTION
The secret sauce: save the scaled images as `.tiff` instead of PNG.

Also fixes a bug where the Image board disk/mem cache settings weren't getting set or returned in the service calls.