### PR TITLE
Performance Improvements for Combined Scroll

### DIFF
--- a/pkg/rgbmatrix-rpi/scroll_canvas.go
+++ b/pkg/rgbmatrix-rpi/scroll_canvas.go
@@ -370,7 +370,7 @@ func (c *ScrollCanvas) rightToLeft(ctx context.Context) error {
 }
 
 func (c *ScrollCanvas) rightToLeftNoMerge(ctx context.Context) error {
-	c.setSubCanvases()
+	c.PrepareSubCanvases()
 
 	finish := c.subCanvases[len(c.subCanvases)-1].virtualEndX
 
@@ -382,6 +382,13 @@ func (c *ScrollCanvas) rightToLeftNoMerge(ctx context.Context) error {
 	)
 
 	pctDone := float64(0)
+
+	defer func() {
+		select {
+		case c.scrollStatus <- 1.0:
+		default:
+		}
+	}()
 
 	for {
 		select {
@@ -420,7 +427,7 @@ func (c *ScrollCanvas) rightToLeftNoMerge(ctx context.Context) error {
 
 func (c *ScrollCanvas) getActualPixel(virtualX int, virtualY int) color.Color {
 	if len(c.subCanvases) < 1 {
-		c.setSubCanvases()
+		c.PrepareSubCanvases()
 	}
 
 	for _, sub := range c.subCanvases {
@@ -433,7 +440,8 @@ func (c *ScrollCanvas) getActualPixel(virtualX int, virtualY int) color.Color {
 	return color.Black
 }
 
-func (c *ScrollCanvas) setSubCanvases() {
+// PrepareSubCanvases
+func (c *ScrollCanvas) PrepareSubCanvases() {
 	if len(c.actuals) < 1 {
 		return
 	}

--- a/pkg/rgbmatrix-rpi/scroll_canvas.go
+++ b/pkg/rgbmatrix-rpi/scroll_canvas.go
@@ -6,6 +6,7 @@ import (
 	"image"
 	"image/color"
 	"image/draw"
+	"sort"
 	"time"
 
 	"github.com/robbydyer/sports/pkg/board"
@@ -33,16 +34,27 @@ const (
 )
 
 type ScrollCanvas struct {
-	w, h      int
-	Matrix    Matrix
-	enabled   *atomic.Bool
-	actual    *image.RGBA
-	direction ScrollDirection
-	interval  time.Duration
-	log       *zap.Logger
-	pad       int
-	actuals   []*image.RGBA
-	merged    *atomic.Bool
+	w, h        int
+	Matrix      Matrix
+	enabled     *atomic.Bool
+	actual      *image.RGBA
+	direction   ScrollDirection
+	interval    time.Duration
+	log         *zap.Logger
+	pad         int
+	actuals     []*image.RGBA
+	merged      *atomic.Bool
+	subCanvases []*subCanvasHorizontal
+	mergePad    int
+}
+
+type subCanvasHorizontal struct {
+	actualStartX  int
+	actualEndX    int
+	virtualStartX int
+	virtualEndX   int
+	img           *image.RGBA
+	index         int
 }
 
 type ScrollCanvasOption func(*ScrollCanvas) error
@@ -148,6 +160,12 @@ func (c *ScrollCanvas) Merge(padding int) {
 	c.actual = merged
 }
 
+func (c *ScrollCanvas) Append(other *ScrollCanvas) {
+	for _, actual := range other.actuals {
+		c.actuals = append(c.actuals, actual)
+	}
+}
+
 func (c *ScrollCanvas) position(x, y int) int {
 	return x + (y * c.w)
 }
@@ -246,6 +264,24 @@ func (c *ScrollCanvas) Render(ctx context.Context) error {
 	return nil
 }
 
+// RenderNoMerge update the display with the data from the LED buffer
+func (c *ScrollCanvas) RenderNoMerge(ctx context.Context, pad int) error {
+	switch c.direction {
+	case RightToLeft:
+		c.log.Debug("scrolling right to left")
+		c.mergePad = pad
+		if err := c.rightToLeftNoMerge(ctx); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("unsupported scroll direction")
+	}
+
+	draw.Draw(c.actual, c.actual.Bounds(), &image.Uniform{color.Black}, image.Point{}, draw.Src)
+
+	return nil
+}
+
 // ColorModel returns the canvas' color model, always color.RGBAModel
 func (c *ScrollCanvas) ColorModel() color.Model {
 	return color.RGBAModel
@@ -327,6 +363,179 @@ func (c *ScrollCanvas) rightToLeft(ctx context.Context) error {
 		}
 		thisX--
 	}
+}
+
+func (c *ScrollCanvas) rightToLeftNoMerge(ctx context.Context) error {
+	c.setSubCanvases()
+
+	finish := c.subCanvases[len(c.subCanvases)-1].virtualEndX
+
+	virtualX := c.subCanvases[0].virtualStartX
+
+	c.log.Debug("performing right to left scroll without canvas merge",
+		zap.Int("virtualX start", virtualX),
+		zap.Int("finish", finish),
+	)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Canceled
+		case <-time.After(c.interval):
+		}
+		if virtualX == finish {
+			return nil
+		}
+
+		for x := 0; x <= c.w; x++ {
+			for y := 0; y <= c.h; y++ {
+				thisVirtualX := x + virtualX
+
+				c.Matrix.Set(c.position(x, y), c.getActualPixel(thisVirtualX, y))
+			}
+		}
+		virtualX++
+
+		if err := c.Matrix.Render(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *ScrollCanvas) getActualPixel(virtualX int, virtualY int) color.Color {
+	if len(c.subCanvases) < 1 {
+		c.setSubCanvases()
+	}
+
+	for _, sub := range c.subCanvases {
+		if virtualX >= sub.virtualStartX && virtualX <= sub.virtualEndX {
+			actualX := (virtualX - sub.virtualStartX) + sub.actualStartX
+			/*
+				c.log.Debug("found pixel",
+					zap.Int("myX", x-diff),
+					zap.Int("virtualX", x),
+				)
+			*/
+			return sub.img.At(actualX, virtualY)
+		}
+	}
+
+	c.log.Debug("no pixel found",
+		zap.Int("x", virtualX),
+		zap.Int("y", virtualY),
+	)
+
+	return color.Black
+}
+
+func (c *ScrollCanvas) setSubCanvases() {
+	if len(c.actuals) < 1 {
+		return
+	}
+	c.subCanvases = []*subCanvasHorizontal{
+		{
+			index:         0,
+			actualStartX:  0,
+			actualEndX:    c.w,
+			virtualStartX: 0,
+			virtualEndX:   c.w,
+			img:           image.NewRGBA(image.Rect(0, 0, c.w, c.h)),
+		},
+	}
+
+	index := 1
+	for _, actual := range c.actuals {
+		c.subCanvases = append(c.subCanvases,
+			&subCanvasHorizontal{
+				actualStartX: firstNonBlankX(actual),
+				actualEndX:   lastNonBlankX(actual),
+				img:          actual,
+				index:        index,
+			},
+		)
+		index++
+		c.subCanvases = append(c.subCanvases,
+			&subCanvasHorizontal{
+				actualStartX: 0,
+				actualEndX:   c.mergePad,
+				img:          image.NewRGBA(image.Rect(0, 0, c.mergePad, c.h)),
+				index:        index,
+			},
+		)
+		index++
+	}
+
+	c.subCanvases = append(c.subCanvases,
+		&subCanvasHorizontal{
+			index:        index,
+			actualStartX: 0,
+			actualEndX:   c.w,
+			img:          image.NewRGBA(image.Rect(0, 0, c.w, c.h)),
+		},
+	)
+
+	sort.SliceStable(c.subCanvases, func(i int, j int) bool {
+		return c.subCanvases[i].index < c.subCanvases[j].index
+	})
+
+	c.log.Debug("done initializing sub canvases",
+		zap.Int("num", len(c.subCanvases)),
+	)
+
+SUBS:
+	for _, sub := range c.subCanvases {
+		if sub.index == 0 {
+			continue SUBS
+		}
+
+		prev := c.prevSub(sub)
+
+		if prev == nil {
+			continue SUBS
+		}
+
+		sub.virtualStartX = prev.virtualEndX + 1
+		diff := sub.actualEndX - sub.actualStartX
+		if sub.actualStartX < 1 {
+			diff = sub.actualEndX - (sub.actualStartX * -1)
+		}
+		sub.virtualEndX = sub.virtualStartX + diff
+
+		c.log.Debug("define sub canvas",
+			zap.Int("index", sub.index),
+			zap.Int("actualstartX", sub.actualStartX),
+			zap.Int("actualendX", sub.actualEndX),
+			zap.Int("virtualstartX", sub.virtualStartX),
+			zap.Int("virtualendx", sub.virtualEndX),
+			zap.Int("actual canvas Width", c.w),
+		)
+	}
+	c.log.Debug("done defining sub canvases")
+}
+
+func (c *ScrollCanvas) subCanvasEndX() int {
+	return c.subCanvases[len(c.subCanvases)-1].virtualEndX
+}
+
+func (c *ScrollCanvas) prevSub(me *subCanvasHorizontal) *subCanvasHorizontal {
+	if me.index == 0 {
+		return nil
+	}
+	for _, sub := range c.subCanvases {
+		if sub.index == me.index-1 {
+			return sub
+		}
+	}
+	return nil
+}
+
+func (c *ScrollCanvas) prevXSum(me *subCanvasHorizontal) int {
+	prev := c.prevSub(me)
+	if prev == nil {
+		return 0
+	}
+	return me.actualEndX + c.prevXSum(me)
 }
 
 func (c *ScrollCanvas) topToBottom(ctx context.Context) error {

--- a/pkg/sportboard/sportboard.go
+++ b/pkg/sportboard/sportboard.go
@@ -454,16 +454,13 @@ func (s *SportBoard) Render(ctx context.Context, canvas board.Canvas) error {
 // ScrollRender ...
 func (s *SportBoard) ScrollRender(ctx context.Context, canvas board.Canvas, padding int) (board.Canvas, error) {
 	origScrollMode := s.config.ScrollMode.Load()
-	origPad := s.config.TightScrollPadding
 	origTight := s.config.TightScroll.Load()
 	defer func() {
 		s.config.ScrollMode.Store(origScrollMode)
-		s.config.TightScrollPadding = origPad
 		s.config.TightScroll.Store(origTight)
 	}()
 
 	s.config.ScrollMode.Store(true)
-	s.config.TightScrollPadding = padding
 	s.config.TightScroll.Store(true)
 
 	return s.render(ctx, canvas)

--- a/pkg/sportsmatrix/sportsmatrix.go
+++ b/pkg/sportsmatrix/sportsmatrix.go
@@ -623,6 +623,10 @@ CANVASES:
 			scrollCanvas.AddCanvas(ordered.scrollCanvas)
 		}
 
+		scrollCanvas.PrepareSubCanvases()
+
+		s.log.Debug("prepared combined canvas, waiting for previous to finish")
+
 		ticker := time.NewTicker(500 * time.Millisecond)
 	WAIT:
 		for {
@@ -650,6 +654,7 @@ CANVASES:
 		}()
 
 		s.waitForScroll(ctx, 0.7, 5*time.Minute)
+		s.log.Debug("done waiting for combined scroll")
 	}
 
 	return nil
@@ -665,7 +670,10 @@ func (s *SportsMatrix) waitForScroll(ctx context.Context, waitFor float64, timeo
 		)
 		return
 	case status := <-s.scrollStatus:
-		if status > waitFor {
+		s.log.Debug("scroll progress",
+			zap.Float64("percentage", status*100),
+		)
+		if status >= waitFor {
 			return
 		}
 	}

--- a/pkg/sportsmatrix/sportsmatrix.go
+++ b/pkg/sportsmatrix/sportsmatrix.go
@@ -619,8 +619,8 @@ CANVASES:
 			scrollCanvas.AddCanvas(ordered.scrollCanvas)
 		}
 
-		scrollCanvas.Merge(s.cfg.CombinedScrollPadding)
-		if err := scrollCanvas.Render(ctx); err != nil {
+		// scrollCanvas.Merge(s.cfg.CombinedScrollPadding)
+		if err := scrollCanvas.RenderNoMerge(ctx, s.cfg.CombinedScrollPadding); err != nil {
 			return err
 		}
 	}

--- a/pkg/sportsmatrix/sportsmatrix.go
+++ b/pkg/sportsmatrix/sportsmatrix.go
@@ -55,6 +55,8 @@ type SportsMatrix struct {
 	webBoardCtx        context.Context
 	webBoardCancel     context.CancelFunc
 	liveOnly           *atomic.Bool
+	scrollStatus       chan float64
+	scrollInProgress   *atomic.Bool
 	sync.Mutex
 }
 
@@ -142,22 +144,24 @@ func New(ctx context.Context, logger *zap.Logger, cfg *Config, canvases []board.
 	cfg.Defaults()
 
 	s := &SportsMatrix{
-		boards:        boards,
-		cfg:           cfg,
-		log:           logger,
-		serveBlock:    make(chan struct{}),
-		close:         make(chan struct{}),
-		screenIsOn:    atomic.NewBool(true),
-		webBoardIsOn:  atomic.NewBool(false),
-		webBoardOn:    make(chan struct{}),
-		webBoardOff:   make(chan struct{}),
-		isServing:     make(chan struct{}, 1),
-		jumpTo:        make(chan string, 1),
-		canvases:      canvases,
-		jumping:       atomic.NewBool(false),
-		screenSwitch:  make(chan struct{}, 1),
-		webBoardWasOn: atomic.NewBool(false),
-		liveOnly:      atomic.NewBool(false),
+		boards:           boards,
+		cfg:              cfg,
+		log:              logger,
+		serveBlock:       make(chan struct{}),
+		close:            make(chan struct{}),
+		screenIsOn:       atomic.NewBool(true),
+		webBoardIsOn:     atomic.NewBool(false),
+		webBoardOn:       make(chan struct{}),
+		webBoardOff:      make(chan struct{}),
+		isServing:        make(chan struct{}, 1),
+		jumpTo:           make(chan string, 1),
+		canvases:         canvases,
+		jumping:          atomic.NewBool(false),
+		screenSwitch:     make(chan struct{}, 1),
+		webBoardWasOn:    atomic.NewBool(false),
+		liveOnly:         atomic.NewBool(false),
+		scrollStatus:     make(chan float64),
+		scrollInProgress: atomic.NewBool(false),
 	}
 
 	s.boardCtx, s.boardCancel = context.WithCancel(context.Background())
@@ -619,13 +623,52 @@ CANVASES:
 			scrollCanvas.AddCanvas(ordered.scrollCanvas)
 		}
 
-		// scrollCanvas.Merge(s.cfg.CombinedScrollPadding)
-		if err := scrollCanvas.RenderNoMerge(ctx, s.cfg.CombinedScrollPadding); err != nil {
-			return err
+		ticker := time.NewTicker(500 * time.Millisecond)
+	WAIT:
+		for {
+			if !s.scrollInProgress.Load() {
+				break WAIT
+			}
+			select {
+			case <-ctx.Done():
+				return context.Canceled
+			case <-ticker.C:
+			}
 		}
+
+		go func() {
+			s.scrollInProgress.Store(true)
+			defer func() {
+				s.scrollInProgress.Store(false)
+			}()
+
+			if err := scrollCanvas.RenderNoMerge(ctx, s.cfg.CombinedScrollPadding, s.scrollStatus); err != nil {
+				s.log.Error("combined scroll failed",
+					zap.Error(err),
+				)
+			}
+		}()
+
+		s.waitForScroll(ctx, 0.7, 5*time.Minute)
 	}
 
 	return nil
+}
+
+func (s *SportsMatrix) waitForScroll(ctx context.Context, waitFor float64, timeout time.Duration) {
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(timeout):
+		s.log.Error("timed out waiting for scroll",
+			zap.Duration("timeout", timeout),
+		)
+		return
+	case status := <-s.scrollStatus:
+		if status > waitFor {
+			return
+		}
+	}
 }
 
 func (s *SportsMatrix) doBoard(ctx context.Context, b board.Board) error {

--- a/pkg/stockboard/stockboard.go
+++ b/pkg/stockboard/stockboard.go
@@ -260,14 +260,11 @@ func (s *StockBoard) Render(ctx context.Context, canvas board.Canvas) error {
 // ScrollRender ...
 func (s *StockBoard) ScrollRender(ctx context.Context, canvas board.Canvas, padding int) (board.Canvas, error) {
 	origScrollMode := s.config.ScrollMode.Load()
-	origPad := s.config.TightScrollPadding
 	defer func() {
 		s.config.ScrollMode.Store(origScrollMode)
-		s.config.TightScrollPadding = origPad
 	}()
 
 	s.config.ScrollMode.Store(true)
-	s.config.TightScrollPadding = padding
 
 	return s.render(ctx, canvas)
 }

--- a/pkg/weatherboard/weatherboard.go
+++ b/pkg/weatherboard/weatherboard.go
@@ -256,14 +256,11 @@ func (w *WeatherBoard) Render(ctx context.Context, canvas board.Canvas) error {
 // ScrollRender ...
 func (w *WeatherBoard) ScrollRender(ctx context.Context, canvas board.Canvas, padding int) (board.Canvas, error) {
 	origScrollMode := w.config.ScrollMode.Load()
-	origPad := w.config.TightScrollPadding
 	defer func() {
 		w.config.ScrollMode.Store(origScrollMode)
-		w.config.TightScrollPadding = origPad
 	}()
 
 	w.config.ScrollMode.Store(true)
-	w.config.TightScrollPadding = padding
 
 	return w.render(ctx, canvas)
 }


### PR DESCRIPTION
This changes the way the scroll canvas manages the large amount of data for the combined scroll mode. It also will pre-fetch data for the next iteration in a combined scroll to speed up the transition.

This also removes the padding override in combined mode, so that each board type controls its own padding settings.