### PR TITLE
Add stickyDelay config option

### DIFF
--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -315,7 +315,6 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 		}
 
 		layers.ClearLayers()
-
 	}
 }
 

--- a/pkg/sportboard/render.go
+++ b/pkg/sportboard/render.go
@@ -116,6 +116,9 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 		gradientLayers = s.gradientLayer(rgbrender.ZeroedBounds(canvas.Bounds()), len(strings.ReplaceAll(score, " ", "")))
 	}
 
+	stickyStart := time.Now()
+	stickyDelay := s.getStickyDelay()
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -281,6 +284,12 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 			return nil
 		}
 
+		if stickyDelay != nil {
+			if time.Since(stickyStart) > *stickyDelay {
+				return nil
+			}
+		}
+
 		if err := canvas.Render(ctx); err != nil {
 			return err
 		}
@@ -306,6 +315,7 @@ func (s *SportBoard) renderLiveGame(ctx context.Context, canvas board.Canvas, li
 		}
 
 		layers.ClearLayers()
+
 	}
 }
 

--- a/pkg/sportboard/sportboard.go
+++ b/pkg/sportboard/sportboard.go
@@ -57,7 +57,6 @@ type SportBoard struct {
 	stateChangeNotifier board.StateChangeNotifier
 	renderCtx           context.Context
 	renderCancel        context.CancelFunc
-	stickyStart         time.Time
 	sync.Mutex
 }
 

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -195,6 +195,10 @@ ncaafConfig:
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
 
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
+
   # Set to true to show a team's record on the scoreboard
   showRecord: false
 
@@ -291,6 +295,10 @@ nhlConfig:
 
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
+
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
 
   # WARNING: This setting is currently unsupported for NHL
   # Set to true to show a team's record on the scoreboard
@@ -394,6 +402,10 @@ mlbConfig:
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
 
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
+
   # WARNING: This setting is currently unsupported for MLB
   # Set to true to show a team's record on the scoreboard
   showRecord: false
@@ -487,6 +499,10 @@ ncaamConfig:
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
 
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
+
   # Set to true to show a team's record on the scoreboard
   showRecord: false
 
@@ -574,6 +590,10 @@ nbaConfig:
 
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
+
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
 
   # Set to true to show a team's record on the scoreboard
   showRecord: false
@@ -663,6 +683,10 @@ nflConfig:
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
 
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
+
   # Set to true to show a team's record on the scoreboard
   showRecord: false
 
@@ -751,6 +775,10 @@ mlsConfig:
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
 
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
+
   # Set to true to show a team's record on the scoreboard
   showRecord: false
 
@@ -838,6 +866,10 @@ eplConfig:
 
   # Tells the matrix to lock onto a live game that a favorite team is playing in
   favoriteSticky: false
+
+  # If this is set and favoriteSticky is enabled, live sticky games will exit the sticky
+  # cycle every stickyDelay interval. They will re-stick the favorited games once the cycle comes back around.
+  #stickyDelay: "5m"
 
   # Set to true to show a team's record on the scoreboard
   showRecord: false


### PR DESCRIPTION
Support for idea from https://github.com/robbydyer/sports/issues/242

Adds a `stickyDelay` option for each sport that will break out of the sticky loop on a given interval.