### PR TITLE
Setting for previous/advance schedule days

### DIFF
--- a/cmd/sportsmatrix/main.go
+++ b/cmd/sportsmatrix/main.go
@@ -57,6 +57,7 @@ type rootArgs struct {
 	writer       *os.File
 	alternateAPI bool
 	debug        bool
+	todayT       time.Time
 }
 
 func main() {
@@ -474,7 +475,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.NHLConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.NHLConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -536,7 +537,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 		headlineAPI := espnboard.NewHeadlines(l, logger)
 		opts = append(opts, sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo))
 
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.MLBConfig, opts...)
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.MLBConfig, opts...)
 		if err != nil {
 			return boards, err
 		}
@@ -568,7 +569,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
 
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.NCAAMConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.NCAAMConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -596,7 +597,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
 
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.NCAAFConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.NCAAFConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -623,7 +624,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
 
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.NBAConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.NBAConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -650,7 +651,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
 
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.NFLConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.NFLConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -677,7 +678,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.MLSConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.MLSConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -704,7 +705,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.EPLConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.EPLConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -732,7 +733,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.DFLConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.DFLConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -760,7 +761,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.DFBConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.DFBConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -788,7 +789,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.UEFAConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.UEFAConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -816,7 +817,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 			return nil, err
 		}
 		headlineAPI := espnboard.NewHeadlines(l, logger)
-		b, err := sportboard.New(ctx, api, bounds, logger, r.config.FIFAConfig,
+		b, err := sportboard.New(ctx, api, bounds, r.todayT, logger, r.config.FIFAConfig,
 			sportboard.WithLeagueLogoGetter(headlineAPI.GetLogo),
 		)
 		if err != nil {
@@ -950,36 +951,23 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 
 func (r *rootArgs) setTodayFuncs(today string) error {
 	if today == "" {
+		r.todayT = util.Today()[0]
 		return nil
 	}
 
-	t, err := time.Parse("2006-01-02T15:04:05", fmt.Sprintf("%sT12:00:00", today))
+	var err error
+	r.todayT, err = time.Parse("2006-01-02T15:04:05", fmt.Sprintf("%sT12:00:00", today))
 	if err != nil {
 		return err
 	}
 
-	f := func() []time.Time {
-		return []time.Time{t}
-	}
-
-	r.config.NHLConfig.TodayFunc = f
-	r.config.MLBConfig.TodayFunc = f
-	r.config.NCAAMConfig.TodayFunc = f
-	r.config.NBAConfig.TodayFunc = f
-	r.config.MLSConfig.TodayFunc = f
-	r.config.EPLConfig.TodayFunc = f
-	r.config.DFLConfig.TodayFunc = f
-	r.config.DFBConfig.TodayFunc = f
-	r.config.UEFAConfig.TodayFunc = f
-	r.config.FIFAConfig.TodayFunc = f
-
 	ncaafF := func() []time.Time {
-		return util.NCAAFToday(t)
+		return util.NCAAFToday(r.todayT)
 	}
 	r.config.NCAAFConfig.TodayFunc = ncaafF
 
 	nflF := func() []time.Time {
-		return util.NFLToday(t)
+		return util.NFLToday(r.todayT)
 	}
 	r.config.NFLConfig.TodayFunc = nflF
 

--- a/cmd/sportsmatrix/mlbtest.go
+++ b/cmd/sportsmatrix/mlbtest.go
@@ -136,7 +136,7 @@ func (c *mlbCmd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	b, err := sportboard.New(ctx, api, bounds, logger, c.rArgs.config.MLBConfig, sportboard.WithDetailedLiveRenderer(dR))
+	b, err := sportboard.New(ctx, api, bounds, c.rArgs.todayT, logger, c.rArgs.config.MLBConfig, sportboard.WithDetailedLiveRenderer(dR))
 	if err != nil {
 		return err
 	}

--- a/internal/board/sport/sportboard.go
+++ b/internal/board/sport/sportboard.go
@@ -111,6 +111,8 @@ type Config struct {
 	DetailedLive         *atomic.Bool      `json:"detailedLive"`
 	ShowLeagueLogo       *atomic.Bool      `json:"showLeagueLogo"`
 	Enable24Hour         *atomic.Bool      `json:"enable24Hour"`
+	AdvanceDays          int               `json:"advanceDays"`
+	PreviousDays         int               `json:"previousDays"`
 }
 
 // FontConfig ...
@@ -244,7 +246,7 @@ func (c *Config) SetDefaults() {
 }
 
 // New ...
-func New(ctx context.Context, api API, bounds image.Rectangle, logger *zap.Logger, config *Config, opts ...OptionFunc) (*SportBoard, error) {
+func New(ctx context.Context, api API, bounds image.Rectangle, today time.Time, logger *zap.Logger, config *Config, opts ...OptionFunc) (*SportBoard, error) {
 	s := &SportBoard{
 		config:          config,
 		api:             api,
@@ -259,6 +261,10 @@ func New(ctx context.Context, api API, bounds image.Rectangle, logger *zap.Logge
 		enabler:         enabler.New(),
 	}
 
+	// Set todayFunc
+	if s.config.TodayFunc == nil {
+	}
+
 	if config.StartEnabled.Load() {
 		s.enabler.Enable()
 	}
@@ -270,6 +276,11 @@ func New(ctx context.Context, api API, bounds image.Rectangle, logger *zap.Logge
 
 	if s.config.TodayFunc == nil {
 		s.config.TodayFunc = util.Today
+		if s.config.PreviousDays > 0 || s.config.AdvanceDays > 0 {
+			s.config.TodayFunc = func() []time.Time {
+				return util.AddTodays(today, s.config.PreviousDays, s.config.AdvanceDays)
+			}
+		}
 		if strings.ToLower(s.api.League()) == "ncaaf" {
 			f := func() []time.Time {
 				return util.NCAAFToday(util.Today()[0])

--- a/internal/board/sport/sportboard.go
+++ b/internal/board/sport/sportboard.go
@@ -261,10 +261,6 @@ func New(ctx context.Context, api API, bounds image.Rectangle, today time.Time, 
 		enabler:         enabler.New(),
 	}
 
-	// Set todayFunc
-	if s.config.TodayFunc == nil {
-	}
-
 	if config.StartEnabled.Load() {
 		s.enabler.Enable()
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -99,6 +99,25 @@ func NFLToday(t time.Time) []time.Time {
 	return todays
 }
 
+func AddTodays(today time.Time, previousDays int, advanceDays int) []time.Time {
+	todays := []time.Time{}
+
+	if previousDays > 0 {
+		for i := 1; i <= previousDays; i++ {
+			todays = append(todays, today.AddDate(0, 0, -1*i))
+		}
+	}
+	todays = append(todays, today)
+
+	if advanceDays > 0 {
+		for i := 1; i <= advanceDays; i++ {
+			todays = append(todays, today.AddDate(0, 0, i))
+		}
+	}
+
+	return todays
+}
+
 // PullPng GETs a png and returns it decoded as an image.Image
 func PullPng(ctx context.Context, url string) (image.Image, error) {
 	req, err := http.NewRequest("GET", url, nil)

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -355,6 +355,12 @@ nhlConfig:
   # 24 Hour Clock format for Game schedules
   enable24Hour: false
 
+  # Number of days in advance to show scheduled games for. Defaults to today only
+  advanceDays: 0
+
+  # Number of previous days to show scores for. Defaults to today only
+  previousDays: 0
+
 ## MLB Config
 mlbConfig:
   enabled: true


### PR DESCRIPTION
Allows each sport to have a number of previous and advance days to show scores/schedule beyond just that day's.

```
 # Number of days in advance to show scheduled games for. Defaults to today only
 advanceDays: 0
 # Number of previous days to show scores for. Defaults to today only
 previousDays: 0
```