### PR TITLE
Fix --date-str and NFL/NCAAF postseason schedule

### DIFF
--- a/cmd/sportsmatrix/mlbtest.go
+++ b/cmd/sportsmatrix/mlbtest.go
@@ -132,9 +132,6 @@ func (c *mlbCmd) run(cmd *cobra.Command, args []string) error {
 	c.rArgs.config.MLBConfig.DetailedLive.Store(true)
 	c.rArgs.config.MLBConfig.GridCols = 0
 	c.rArgs.config.MLBConfig.GridRows = 0
-	if err := c.rArgs.setTodayFuncs("2022-05-23"); err != nil {
-		return err
-	}
 
 	b, err := sportboard.New(ctx, api, bounds, c.rArgs.todayT, logger, c.rArgs.config.MLBConfig, sportboard.WithDetailedLiveRenderer(dR))
 	if err != nil {

--- a/internal/board/calendar/calendarboard.go
+++ b/internal/board/calendar/calendarboard.go
@@ -116,7 +116,7 @@ func New(api API, logger *zap.Logger, config *Config) (*CalendarBoard, error) {
 	)
 
 	if s.config.TodayFunc == nil {
-		s.config.TodayFunc = util.Today
+		s.config.TodayFunc = util.TodayFunc(time.Now())
 	}
 
 	if err := util.SetCrons(config.OnTimes, func() {

--- a/internal/board/racing/racingboard.go
+++ b/internal/board/racing/racingboard.go
@@ -123,7 +123,7 @@ func New(api API, logger *zap.Logger, config *Config) (*RacingBoard, error) {
 	}
 
 	if s.config.TodayFunc == nil {
-		s.config.TodayFunc = util.Today
+		s.config.TodayFunc = util.TodayFunc(time.Now())
 	}
 
 	if err := util.SetCrons(config.OnTimes, func() {

--- a/internal/board/sport/sportboard.go
+++ b/internal/board/sport/sportboard.go
@@ -271,7 +271,7 @@ func New(ctx context.Context, api API, bounds image.Rectangle, today time.Time, 
 	}
 
 	if s.config.TodayFunc == nil {
-		s.config.TodayFunc = util.Today
+		s.config.TodayFunc = util.TodayFunc(today)
 		if s.config.PreviousDays > 0 || s.config.AdvanceDays > 0 {
 			s.config.TodayFunc = func() []time.Time {
 				return util.AddTodays(today, s.config.PreviousDays, s.config.AdvanceDays)
@@ -279,13 +279,13 @@ func New(ctx context.Context, api API, bounds image.Rectangle, today time.Time, 
 		}
 		if strings.ToLower(s.api.League()) == "ncaaf" {
 			f := func() []time.Time {
-				return util.NCAAFToday(util.Today()[0])
+				return util.NCAAFToday(util.Today(today))
 			}
 			s.config.TodayFunc = f
 		}
 		if strings.ToLower(s.api.League()) == "nfl" {
 			f := func() []time.Time {
-				return util.NFLToday(util.Today()[0])
+				return util.NFLToday(util.Today(today))
 			}
 			s.config.TodayFunc = f
 		}

--- a/internal/nhl/player.go
+++ b/internal/nhl/player.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -191,9 +192,7 @@ func (p *Player) setStats(ctx context.Context) error {
 	v := uri.Query()
 	v.Set("stats", "statsSingleSeason")
 
-	if len(util.Today()) > 0 {
-		v.Set("season", GetSeason(util.Today()[0]))
-	}
+	v.Set("season", GetSeason(util.Today(time.Now())))
 
 	uri.RawQuery = v.Encode()
 

--- a/internal/nhl/team.go
+++ b/internal/nhl/team.go
@@ -155,16 +155,11 @@ OUTER:
 
 func (n *NHL) getTeamAPIData(ctx context.Context) ([]byte, error) {
 	season := ""
-	if d := util.Today(); len(d) > 0 {
-		season = fmt.Sprintf("season=%s", GetSeason(d[0]))
-		n.log.Debug("nhl today season",
-			zap.String("util.Today", d[0].String()),
-		)
-	} else {
-		n.log.Error("failed to determine today",
-			zap.String("league", n.LeagueShortName()),
-		)
-	}
+	d := util.Today(time.Now())
+	season = fmt.Sprintf("season=%s", GetSeason(d))
+	n.log.Debug("nhl today season",
+		zap.String("util.Today", d.String()),
+	)
 	uri := fmt.Sprintf("%s/teams?expand=team.roster,team.schedule.next&%s", baseURL, season)
 	n.log.Debug("fetching team data from API",
 		zap.String("league", n.LeagueShortName()),

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -13,90 +13,207 @@ import (
 )
 
 // Today is sometimes actually yesterday
-func Today() []time.Time {
-	if time.Now().Local().Hour() < 4 {
-		return []time.Time{time.Now().AddDate(0, 0, -1).Local()}
+func Today(t time.Time) time.Time {
+	if t.Local().Hour() < 4 {
+		return t.AddDate(0, 0, -1).Local()
 	}
 
-	return []time.Time{time.Now().Local()}
+	return t.Local()
+}
+
+func TodayFunc(t time.Time) func() []time.Time {
+	return func() []time.Time {
+		return []time.Time{Today(t)}
+	}
 }
 
 // NCAAFToday takes a single "today" time and adds thurs-sat games for the coming week.
 // Sunday shows previous week's scores
 func NCAAFToday(t time.Time) []time.Time {
-	var todays []time.Time
+	// Bowl season is weird
+	if t.Month() == time.December || t.Month() == time.January {
+		switch t.Weekday() {
+		case time.Monday:
+			return []time.Time{
+				t,
+				t.AddDate(0, 0, 1),
+				t.AddDate(0, 0, 2),
+				t.AddDate(0, 0, 3),
+				t.AddDate(0, 0, 4),
+				t.AddDate(0, 0, 5),
+				t.AddDate(0, 0, 6),
+			}
+		case time.Tuesday:
+			return []time.Time{
+				t.AddDate(0, 0, -1),
+				t,
+				t.AddDate(0, 0, 1),
+				t.AddDate(0, 0, 2),
+				t.AddDate(0, 0, 3),
+				t.AddDate(0, 0, 4),
+				t.AddDate(0, 0, 5),
+			}
+		case time.Wednesday:
+			return []time.Time{
+				t.AddDate(0, 0, -2),
+				t.AddDate(0, 0, -1),
+				t,
+				t.AddDate(0, 0, 1),
+				t.AddDate(0, 0, 2),
+				t.AddDate(0, 0, 3),
+				t.AddDate(0, 0, 4),
+			}
+		case time.Thursday:
+			return []time.Time{
+				t.AddDate(0, 0, -3),
+				t.AddDate(0, 0, -2),
+				t.AddDate(0, 0, -1),
+				t,
+				t.AddDate(0, 0, 1),
+				t.AddDate(0, 0, 2),
+				t.AddDate(0, 0, 3),
+			}
+		case time.Friday:
+			return []time.Time{
+				t.AddDate(0, 0, -4),
+				t.AddDate(0, 0, -3),
+				t.AddDate(0, 0, -2),
+				t.AddDate(0, 0, -1),
+				t,
+				t.AddDate(0, 0, 1),
+				t.AddDate(0, 0, 2),
+			}
+		case time.Saturday:
+			return []time.Time{
+				t.AddDate(0, 0, -5),
+				t.AddDate(0, 0, -4),
+				t.AddDate(0, 0, -3),
+				t.AddDate(0, 0, -2),
+				t.AddDate(0, 0, -1),
+				t,
+				t.AddDate(0, 0, 1),
+			}
+		case time.Sunday:
+			return []time.Time{
+				t.AddDate(0, 0, -6),
+				t.AddDate(0, 0, -5),
+				t.AddDate(0, 0, -4),
+				t.AddDate(0, 0, -3),
+				t.AddDate(0, 0, -2),
+				t.AddDate(0, 0, -1),
+				t,
+			}
+		}
+
+		return []time.Time{t}
+	}
+
 	// Do Thurs-Saturday of the coming week
 	switch t.Weekday() {
 	case time.Monday:
-		todays = append(todays, t.AddDate(0, 0, 3))
-		todays = append(todays, t.AddDate(0, 0, 4))
-		todays = append(todays, t.AddDate(0, 0, 5))
+		return []time.Time{
+			t.AddDate(0, 0, 3),
+			t.AddDate(0, 0, 4),
+			t.AddDate(0, 0, 5),
+		}
 	case time.Tuesday:
-		todays = append(todays, t.AddDate(0, 0, 2))
-		todays = append(todays, t.AddDate(0, 0, 3))
-		todays = append(todays, t.AddDate(0, 0, 4))
+		return []time.Time{
+			t.AddDate(0, 0, 2),
+			t.AddDate(0, 0, 3),
+			t.AddDate(0, 0, 4),
+		}
 	case time.Wednesday:
-		todays = append(todays, t.AddDate(0, 0, 1))
-		todays = append(todays, t.AddDate(0, 0, 2))
-		todays = append(todays, t.AddDate(0, 0, 3))
+		return []time.Time{
+			t.AddDate(0, 0, 1),
+			t.AddDate(0, 0, 2),
+			t.AddDate(0, 0, 3),
+		}
 	case time.Thursday:
-		todays = append(todays, t)
-		todays = append(todays, t.AddDate(0, 0, 1))
-		todays = append(todays, t.AddDate(0, 0, 2))
+		return []time.Time{
+			t,
+			t.AddDate(0, 0, 1),
+			t.AddDate(0, 0, 2),
+		}
 	case time.Friday:
-		todays = append(todays, t)
-		todays = append(todays, t.AddDate(0, 0, -1))
-		todays = append(todays, t.AddDate(0, 0, 1))
+		return []time.Time{
+			t,
+			t.AddDate(0, 0, -1),
+			t.AddDate(0, 0, 1),
+		}
 	case time.Saturday:
-		todays = append(todays, t)
-		todays = append(todays, t.AddDate(0, 0, -1))
-		todays = append(todays, t.AddDate(0, 0, -2))
+		return []time.Time{
+			t,
+			t.AddDate(0, 0, -1),
+			t.AddDate(0, 0, -2),
+		}
 	case time.Sunday:
-		todays = append(todays, t.AddDate(0, 0, -1))
-		todays = append(todays, t.AddDate(0, 0, -2))
-		todays = append(todays, t.AddDate(0, 0, -3))
+		return []time.Time{
+			t.AddDate(0, 0, -1),
+			t.AddDate(0, 0, -2),
+			t.AddDate(0, 0, -3),
+		}
 	}
 
-	return todays
+	return []time.Time{t}
 }
 
 // NFLToday takes a single "today" time and adds thurs, sun, mon games for the coming week.
 // Monday shows previous week's scores
 func NFLToday(t time.Time) []time.Time {
-	var todays []time.Time
 	// Do Thurs-Sunday of the coming week
 	switch t.Weekday() {
 	case time.Monday:
-		todays = append(todays, t)
-		todays = append(todays, t.AddDate(0, 0, -1))
-		todays = append(todays, t.AddDate(0, 0, -4))
+		return []time.Time{
+			t,
+			t.AddDate(0, 0, -1),
+			t.AddDate(0, 0, -2),
+			t.AddDate(0, 0, -4),
+		}
 	case time.Tuesday:
-		todays = append(todays, t.AddDate(0, 0, 2))
-		todays = append(todays, t.AddDate(0, 0, 5))
-		todays = append(todays, t.AddDate(0, 0, 6))
+		return []time.Time{
+			t.AddDate(0, 0, 2),
+			t.AddDate(0, 0, 4),
+			t.AddDate(0, 0, 5),
+			t.AddDate(0, 0, 6),
+		}
 	case time.Wednesday:
-		todays = append(todays, t.AddDate(0, 0, 1))
-		todays = append(todays, t.AddDate(0, 0, 4))
-		todays = append(todays, t.AddDate(0, 0, 5))
+		return []time.Time{
+			t.AddDate(0, 0, 1),
+			t.AddDate(0, 0, 3),
+			t.AddDate(0, 0, 4),
+			t.AddDate(0, 0, 5),
+		}
 	case time.Thursday:
-		todays = append(todays, t)
-		todays = append(todays, t.AddDate(0, 0, 3))
-		todays = append(todays, t.AddDate(0, 0, 4))
+		return []time.Time{
+			t,
+			t.AddDate(0, 0, 2),
+			t.AddDate(0, 0, 3),
+			t.AddDate(0, 0, 4),
+		}
 	case time.Friday:
-		todays = append(todays, t.AddDate(0, 0, -1))
-		todays = append(todays, t.AddDate(0, 0, 2))
-		todays = append(todays, t.AddDate(0, 0, 3))
+		return []time.Time{
+			t.AddDate(0, 0, -1),
+			t.AddDate(0, 0, 1),
+			t.AddDate(0, 0, 2),
+			t.AddDate(0, 0, 3),
+		}
 	case time.Saturday:
-		todays = append(todays, t.AddDate(0, 0, -2))
-		todays = append(todays, t.AddDate(0, 0, 1))
-		todays = append(todays, t.AddDate(0, 0, 2))
+		return []time.Time{
+			t.AddDate(0, 0, -2),
+			t,
+			t.AddDate(0, 0, 1),
+			t.AddDate(0, 0, 2),
+		}
 	case time.Sunday:
-		todays = append(todays, t.AddDate(0, 0, -3))
-		todays = append(todays, t)
-		todays = append(todays, t.AddDate(0, 0, 1))
+		return []time.Time{
+			t.AddDate(0, 0, -3),
+			t.AddDate(0, 0, -1),
+			t,
+			t.AddDate(0, 0, 1),
+		}
 	}
 
-	return todays
+	return []time.Time{t}
 }
 
 func AddTodays(today time.Time, previousDays int, advanceDays int) []time.Time {


### PR DESCRIPTION
Fixes the `--date-str` option. Also handles the postseason weirdness in NCAAF and NFL schedules where games can fall on not-usual days of the week.