### PR TITLE
Handle new Openweathermap accounts

### DIFF
--- a/cmd/sportsmatrix/main.go
+++ b/cmd/sportsmatrix/main.go
@@ -908,7 +908,7 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 		if r.config.WeatherConfig.APIKey == "" {
 			logger.Warn("Missing Weather API key. Weather Board will not be enabled")
 		} else {
-			api, err := openweather.New(r.config.WeatherConfig.APIKey, 30*time.Minute, logger)
+			api, err := openweather.New(r.config.WeatherConfig.APIKey, 30*time.Minute, r.config.WeatherConfig.APIVersion, logger)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/board/weather/weatherboard.go
+++ b/internal/board/weather/weatherboard.go
@@ -62,6 +62,7 @@ type Config struct {
 	OffTimes           []string     `json:"offTimes"`
 	MetricUnits        *atomic.Bool `json:"metricUnits"`
 	ShowBetween        *atomic.Bool `json:"showBetween"`
+	APIVersion         string       `json:"apiVersion"`
 }
 
 // Forecast ...

--- a/internal/openweather/forecast.go
+++ b/internal/openweather/forecast.go
@@ -8,16 +8,19 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"time"
 
 	"go.uber.org/zap"
 
 	weatherboard "github.com/robbydyer/sports/internal/board/weather"
 	"github.com/robbydyer/sports/internal/rgbrender"
+	"github.com/robbydyer/sports/internal/util"
 )
 
 func (w *weather) expired(refresh time.Duration) bool {
-	return w.lastUpdate.Add(refresh).Before(time.Now().Local())
+	return w.LastUpdate.Add(refresh).Before(time.Now().Local())
 }
 
 func (a *API) boardForecastFromForecast(forecasts []*forecast, bounds image.Rectangle, metric bool) ([]*weatherboard.Forecast, error) {
@@ -99,6 +102,59 @@ func (a *API) weatherFromCache(key string) *weather {
 		return w
 	}
 
+	// Try disk cache
+	cDir, err := cacheDir(dataCacheDir)
+	if err != nil {
+		a.log.Error("failed to get cache dir for weather",
+			zap.Error(err),
+		)
+		return nil
+	}
+
+	cacheFile := filepath.Join(cDir, key)
+	exists, err := util.FileExists(cacheFile)
+	if err != nil {
+		a.log.Error("failed to read weather cache file",
+			zap.String("file", cacheFile),
+			zap.Error(err),
+		)
+		return nil
+	}
+	if exists {
+		dat, err := os.ReadFile(cacheFile)
+		if err != nil {
+			a.log.Error("failed to read weather cache file",
+				zap.String("file", cacheFile),
+				zap.Error(err),
+			)
+			return nil
+		}
+		var w *weather
+
+		if err := json.Unmarshal(dat, &w); err != nil {
+			a.log.Error("failed to unmarshal cached weather data",
+				zap.String("file", cacheFile),
+				zap.Error(err),
+			)
+		}
+		if w == nil {
+			a.log.Error("weather cache data was nil",
+				zap.String("file", cacheFile),
+			)
+
+			return w
+		}
+
+		a.log.Info("got weather data from cache file",
+			zap.String("file", cacheFile),
+			zap.String("key", key),
+		)
+
+		// cache to memory so we don't read the file next time
+		a.cache[key] = w
+		return w
+	}
+
 	a.log.Error("cache miss on weather",
 		zap.String("key", key),
 	)
@@ -109,6 +165,33 @@ func (a *API) weatherFromCache(key string) *weather {
 func (a *API) setWeatherCache(key string, w *weather) {
 	a.forecastLock.Lock()
 	defer a.forecastLock.Unlock()
+
+	// Save cache to file
+	cDir, err := cacheDir(dataCacheDir)
+	if err != nil {
+		a.log.Error("failed to get weather data cache dir",
+			zap.Error(err),
+		)
+		a.cache[key] = w
+		return
+	}
+
+	dat, err := json.Marshal(w)
+	if err != nil {
+		a.log.Error("failed marshal weather for caching",
+			zap.Error(err),
+		)
+	} else {
+		cacheFile := filepath.Join(cDir, key)
+		if err := os.WriteFile(cacheFile, dat, 0o644); err != nil {
+			a.log.Error("failed to write weather cache to file",
+				zap.Error(err),
+			)
+		}
+		a.log.Info("wrote weather data to cache file",
+			zap.String("file", cacheFile),
+		)
+	}
 
 	a.cache[key] = w
 }
@@ -122,7 +205,7 @@ func (a *API) getWeather(ctx context.Context, zipCode string, country string, me
 		if w.expired(a.refresh) {
 			a.log.Info("weather cache expired",
 				zap.Float64("minutes", a.refresh.Minutes()),
-				zap.Time("updated", w.lastUpdate),
+				zap.Time("updated", w.LastUpdate),
 			)
 			w = nil
 		} else {
@@ -155,7 +238,7 @@ func (a *API) getWeather(ctx context.Context, zipCode string, country string, me
 		return nil, fmt.Errorf("failed to geolocate")
 	}
 
-	uri, err := url.Parse(fmt.Sprintf("%s/data/2.5/onecall", baseURL))
+	uri, err := url.Parse(fmt.Sprintf("%s/data/%s/onecall", baseURL, a.apiVersion))
 	if err != nil {
 		return nil, err
 	}
@@ -197,6 +280,15 @@ func (a *API) getWeather(ctx context.Context, zipCode string, country string, me
 		return nil, err
 	}
 
+	if resp.StatusCode == http.StatusUnauthorized {
+		a.log.Error("failed to auth to openweathermap.org",
+			zap.Int("status", resp.StatusCode),
+			zap.String("status message", resp.Status),
+			zap.ByteString("data", body),
+		)
+		return nil, fmt.Errorf("failed to get weather data")
+	}
+
 	a.log.Debug("weather data",
 		zap.ByteString("data", body),
 	)
@@ -208,7 +300,7 @@ func (a *API) getWeather(ctx context.Context, zipCode string, country string, me
 	t := time.Now().Local()
 	a.lastAPICall = &t
 
-	w.lastUpdate = time.Now().Local()
+	w.LastUpdate = time.Now().Local()
 
 	a.setWeatherCache(key, w)
 

--- a/internal/openweather/forecast.go
+++ b/internal/openweather/forecast.go
@@ -166,13 +166,14 @@ func (a *API) setWeatherCache(key string, w *weather) {
 	a.forecastLock.Lock()
 	defer a.forecastLock.Unlock()
 
+	a.cache[key] = w
+
 	// Save cache to file
 	cDir, err := cacheDir(dataCacheDir)
 	if err != nil {
 		a.log.Error("failed to get weather data cache dir",
 			zap.Error(err),
 		)
-		a.cache[key] = w
 		return
 	}
 
@@ -181,19 +182,17 @@ func (a *API) setWeatherCache(key string, w *weather) {
 		a.log.Error("failed marshal weather for caching",
 			zap.Error(err),
 		)
-	} else {
-		cacheFile := filepath.Join(cDir, key)
-		if err := os.WriteFile(cacheFile, dat, 0o644); err != nil {
-			a.log.Error("failed to write weather cache to file",
-				zap.Error(err),
-			)
-		}
-		a.log.Info("wrote weather data to cache file",
-			zap.String("file", cacheFile),
-		)
 	}
 
-	a.cache[key] = w
+	cacheFile := filepath.Join(cDir, key)
+	if err := os.WriteFile(cacheFile, dat, 0o644); err != nil {
+		a.log.Error("failed to write weather cache to file",
+			zap.Error(err),
+		)
+	}
+	a.log.Info("wrote weather data to cache file",
+		zap.String("file", cacheFile),
+	)
 }
 
 func (a *API) getWeather(ctx context.Context, zipCode string, country string, metric bool) (*weather, error) {

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -1407,6 +1407,19 @@ stocksConfig:
 weatherConfig:
   enabled: false
 
+  # Go to openweathermap.org and register an account. You will have to subscribe to the 
+  # "One Call by Call" subscription plan. Don't worry, the matrix app only queries this API every
+  # 30 minutes, so you should never go above the free 1,000 calls per day tier. Data is cached
+  # both in memory and disk to ensure you never call the API more than once every 30 minutes.
+  # Create an API key and put it here.
+  apiKey: ""
+
+  # If you had an openweathermap key prior to their v 3.0 API, you can change this to "2.5".
+  # If you have issues getting weather data, you probably need to set this to the defualt of "3.0"
+  # and ensure that you have subscribed to the "One Call by Call" subscription plan:
+  # https://home.openweathermap.org/subscriptions/unauth_subscribe/onecall_30/base
+  apiVersion: "3.0"
+
   # Set this to true if you want temps in Celsius
   metricUnits: false
 
@@ -1414,9 +1427,6 @@ weatherConfig:
   showBetween: false
 
   scrollMode: true
-
-  # Go to openweathermap.org and register an account, then put your API key here
-  apiKey: ""
 
   # Enter your Zip code here
   zipCode: 90210


### PR DESCRIPTION
Openweathermap accounts opened since their API 3.0 version of the one-call API have to register for a subscription for the API to work. 

This change defaults to v3.0 of the API, which will require the subscription. The matrix will never call the API enough times to trigger a charge, as the free limit is 1,000 calls/day. The matrix will never call the API more than once every 30 minutes. This change adds disk caching of weather data to ensure that even matrix restarts will not trigger extra API calls.