### PR TITLE
Add liveViewFont config option

### DIFF
--- a/cmd/sportsmatrix/main.go
+++ b/cmd/sportsmatrix/main.go
@@ -607,6 +607,10 @@ func (r *rootArgs) getBoards(ctx context.Context, logger *zap.Logger) ([]board.B
 				Logger: logger,
 			}
 
+			if r.config.MLBConfig.LiveViewFont != nil {
+				m.FontSize = r.config.MLBConfig.LiveViewFont.Size
+			}
+
 			opts = append(opts,
 				sportboard.WithDetailedLiveRenderer(
 					func(ctx context.Context, canvas board.Canvas, game sportboard.Game, hLogo *logo.Logo, aLogo *logo.Logo) error {

--- a/internal/board/sport/sportboard.go
+++ b/internal/board/sport/sportboard.go
@@ -85,6 +85,7 @@ type Config struct {
 	StickyDelay          string            `json:"stickyDelay"`
 	ScoreFont            *FontConfig       `json:"scoreFont"`
 	TimeFont             *FontConfig       `json:"timeFont"`
+	LiveViewFont         *FontConfig       `json:"liveViewFont"`
 	LogoConfigs          []*logo.Config    `json:"logoConfigs"`
 	WatchTeams           []string          `json:"watchTeams"`
 	FavoriteTeams        []string          `json:"favoriteTeams"`

--- a/internal/logo/logo.go
+++ b/internal/logo/logo.go
@@ -97,6 +97,10 @@ func (l *Logo) GetThumbnail(ctx context.Context, size image.Rectangle) (image.Im
 				}
 			}
 
+			if l.sourceLogoGetter == nil {
+				return nil, fmt.Errorf("sourceLogoGetter was nil")
+			}
+
 			src, err := l.sourceLogoGetter(ctx)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get logo source for %s: %w", l.config.Abbrev, err)

--- a/internal/mlblive/mlblive.go
+++ b/internal/mlblive/mlblive.go
@@ -18,8 +18,9 @@ import (
 var fillColor = color.RGBA{255, 255, 0, 100}
 
 type MlbLive struct {
-	Logger *zap.Logger
-	writer *rgbrender.TextWriter
+	Logger   *zap.Logger
+	FontSize float64
+	writer   *rgbrender.TextWriter
 }
 
 type Runners struct {
@@ -298,10 +299,14 @@ func (m *MlbLive) getWriter(canvasBounds image.Rectangle) (*rgbrender.TextWriter
 		return nil, err
 	}
 
-	if canvasBounds.Dy() <= 256 {
-		w.FontSize = 8.0
+	if m.FontSize > 0 {
+		w.FontSize = m.FontSize
 	} else {
-		w.FontSize = 0.25 * float64(canvasBounds.Dy())
+		if canvasBounds.Dy() <= 256 {
+			w.FontSize = 8.0
+		} else {
+			w.FontSize = 0.25 * float64(canvasBounds.Dy())
+		}
 	}
 
 	if canvasBounds.Dy() <= 256 {

--- a/sportsmatrix.conf.example
+++ b/sportsmatrix.conf.example
@@ -474,6 +474,9 @@ mlbConfig:
     #size: 8.0
   #scoreFont:
     #size: 16.0
+  # Adjust the font size in the special detail live view
+  #liveViewFont:
+    #size: 16.0
 
   # Set this to false to disable the logo gradient effect
   useGradient: true


### PR DESCRIPTION
For https://github.com/robbydyer/sports/issues/570

Adds a new config option under each sport (although only relevant to MLB currently) `liveViewFont` that allows adjusting the font size in the live MLB view.

Example:
```
mlb:
  liveViewFont:
    size: 10
```